### PR TITLE
Cmake features

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,17 +10,43 @@ ENDIF(NOT CMAKE_BUILD_TYPE)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/modules/")
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/bin)
-LINK_DIRECTORIES(${CMAKE_SOURCE_DIR}/lib )
+link_directories(${CMAKE_SOURCE_DIR}/lib)
 
 list(APPEND CMAKE_CXX_FLAGS "-std=c++11")
 
 # ADD_CUSTOM_TARGET(debug ${CMAKE_COMMAND} -DCMAKE_BUILD_TYPE:STRING=Debug ${PROJECT_SOURCE_DIR})
 # ADD_CUSTOM_TARGET(release ${CMAKE_COMMAND} -DCMAKE_BUILD_TYPE:STRING=Release ${PROJECT_SOURCE_DIR})
 
+# find the required packages
+find_package(GLM REQUIRED)
+message(STATUS "GLM included at ${GLM_INCLUDE_DIR}")
+find_package(GLFW3 REQUIRED)
+message(STATUS "Found GLFW3 in ${GLFW3_INCLUDE_DIR}")
+find_package(ASSIMP REQUIRED)
+message(STATUS "Found ASSIMP in ${ASSIMP_INCLUDE_DIR}")
+find_package(SOIL REQUIRED)
+message(STATUS "Found SOIL in ${SOIL_INCLUDE_DIR}")
+find_package(GLEW REQUIRED)
+message(STATUS "Found GLEW in ${GLEW_INCLUDE_DIR}")
+
 if(WIN32)
   set(LIBS glfw3 opengl32 glew32s SOIL assimp)
 elseif (UNIX)
-  set(LIBS GL X11 glfw GLEW SOIL assimp rt dl)
+#  set(LIBS GL X11 glfw GLEW SOIL assimp rt dl)
+  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wall")
+  # Linux packages native to CMake
+  find_package(OpenGL REQUIRED)
+  set(LIBS ${OPENGL_gl_LIBRARY})
+  add_definitions(${OPENGL_DEFINITIONS})
+  find_package(X11 REQUIRED)
+  list(APPEND LIBS ${X11_Xrandr_LIB} ${X11_Xxf86vm_LIB} ${X11_Xi_LIB})
+  find_library(RT_LIB rt)
+  list(APPEND LIBS ${RT_LIB})
+  # append non-native packages
+  list(APPEND LIBS ${GLFW3_LIBRARY})
+  list(APPEND LIBS ${GLEW_LIBRARY})
+  list(APPEND LIBS ${SOIL_LIBRARY})
+  list(APPEND LIBS ${ASSIMP_LIBRARY})
 else()
   set(LIBS )
 endif()
@@ -35,7 +61,7 @@ IF(APPLE)
   SET(APPLE_LIBS ${APPLE_LIBS} /usr/local/lib/libglfw.a)
 ENDIF(APPLE)
 
-set(LIBS ${LIBS} ${APPLE_LIBS})
+#list(LIBS ${LIBS} ${APPLE_LIBS})
 
 set(CHAPTERS
     1.getting_started
@@ -112,6 +138,6 @@ foreach(CHAPTER ${CHAPTERS})
     endforeach(DEMO)
 endforeach(CHAPTER)
 
-include_directories(include)
+#include_directories(${LEARNOPENGL_INCLUDES})
 include_directories(${CMAKE_SOURCE_DIR}/includes)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,11 +32,10 @@ message(STATUS "Found GLEW in ${GLEW_INCLUDE_DIR}")
 if(WIN32)
   set(LIBS glfw3 opengl32 glew32s SOIL assimp)
 elseif (UNIX)
-#  set(LIBS GL X11 glfw GLEW SOIL assimp rt dl)
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wall")
   # Linux packages native to CMake
   find_package(OpenGL REQUIRED)
-  set(LIBS ${OPENGL_gl_LIBRARY})
+  set(LIBS ${OPENGL_gl_LIBRARY}) # setting LIBS for the first time
   add_definitions(${OPENGL_DEFINITIONS})
   find_package(X11 REQUIRED)
   list(APPEND LIBS ${X11_Xrandr_LIB} ${X11_Xxf86vm_LIB} ${X11_Xi_LIB})
@@ -59,9 +58,8 @@ IF(APPLE)
   MARK_AS_ADVANCED(COCOA_LIBRARY OpenGL_LIBRARY)
   SET(APPLE_LIBS ${COCOA_LIBRARY} ${IOKit_LIBRARY} ${OpenGL_LIBRARY})
   SET(APPLE_LIBS ${APPLE_LIBS} /usr/local/lib/libglfw.a)
+  set(LIBS ${LIBS} ${APPLE_LIBS})
 ENDIF(APPLE)
-
-#list(LIBS ${LIBS} ${APPLE_LIBS})
 
 set(CHAPTERS
     1.getting_started
@@ -138,6 +136,8 @@ foreach(CHAPTER ${CHAPTERS})
     endforeach(DEMO)
 endforeach(CHAPTER)
 
-#include_directories(${LEARNOPENGL_INCLUDES})
 include_directories(${CMAKE_SOURCE_DIR}/includes)
+
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/resources DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+
 

--- a/cmake/modules/FindASSIMP.cmake
+++ b/cmake/modules/FindASSIMP.cmake
@@ -1,0 +1,30 @@
+# - Try to find Assimp
+# Once done, this will define
+#
+# ASSIMP_FOUND - system has Assimp
+# ASSIMP_INCLUDE_DIR - the Assimp include directories
+# ASSIMP_LIBRARIES - link these to use Assimp
+FIND_PATH( ASSIMP_INCLUDE_DIR assimp/mesh.h
+	/usr/include
+	/usr/local/include
+	/opt/local/include
+)
+FIND_LIBRARY( ASSIMP_LIBRARY assimp
+	/usr/lib64
+	/usr/lib
+	/usr/local/lib
+	/opt/local/lib
+)
+IF(ASSIMP_INCLUDE_DIR AND ASSIMP_LIBRARY)
+	SET( ASSIMP_FOUND TRUE )
+	SET( ASSIMP_LIBRARIES ${ASSIMP_LIBRARY} )
+ENDIF(ASSIMP_INCLUDE_DIR AND ASSIMP_LIBRARY)
+IF(ASSIMP_FOUND)
+	IF(NOT ASSIMP_FIND_QUIETLY)
+	MESSAGE(STATUS "Found ASSIMP: ${ASSIMP_LIBRARY}")
+	ENDIF(NOT ASSIMP_FIND_QUIETLY)
+ELSE(ASSIMP_FOUND)
+	IF(ASSIMP_FIND_REQUIRED)
+	MESSAGE(FATAL_ERROR "Could not find libASSIMP")
+	ENDIF(ASSIMP_FIND_REQUIRED)
+ENDIF(ASSIMP_FOUND)

--- a/cmake/modules/FindGLEW.cmake
+++ b/cmake/modules/FindGLEW.cmake
@@ -1,0 +1,59 @@
+#
+# Try to find GLEW library and include path.
+# Once done this will define
+#
+# GLEW_FOUND
+# GLEW_INCLUDE_PATH
+# GLEW_LIBRARY
+#
+IF (WIN32)
+	FIND_PATH( GLEW_INCLUDE_PATH GL/glew.h
+	$ENV{PROGRAMFILES}/GLEW/include
+	${GLEW_ROOT_DIR}/include
+	DOC "The directory where GL/glew.h resides")
+	IF (NV_SYSTEM_PROCESSOR STREQUAL "AMD64")
+		FIND_LIBRARY( GLEW_LIBRARY
+			NAMES glew64 glew64s
+			PATHS
+			$ENV{PROGRAMFILES}/GLEW/lib
+			${PROJECT_SOURCE_DIR}/src/nvgl/glew/bin
+			${PROJECT_SOURCE_DIR}/src/nvgl/glew/lib
+			DOC "The GLEW library (64-bit)"
+		)
+	ELSE(NV_SYSTEM_PROCESSOR STREQUAL "AMD64")
+		FIND_LIBRARY( GLEW_LIBRARY
+			NAMES glew GLEW glew32 glew32s
+			PATHS
+			$ENV{PROGRAMFILES}/GLEW/lib
+			${PROJECT_SOURCE_DIR}/src/nvgl/glew/bin
+			${PROJECT_SOURCE_DIR}/src/nvgl/glew/lib
+			DOC "The GLEW library"
+		)
+	ENDIF(NV_SYSTEM_PROCESSOR STREQUAL "AMD64")
+ELSE (WIN32)
+	FIND_PATH( GLEW_INCLUDE_PATH GL/glew.h
+		/usr/include
+		/usr/local/include
+		/sw/include
+		/opt/local/include
+		${GLEW_ROOT_DIR}/include
+		DOC "The directory where GL/glew.h resides")
+	FIND_LIBRARY( GLEW_LIBRARY
+		NAMES GLEW glew
+		PATHS
+		/usr/lib64
+		/usr/lib
+		/usr/local/lib64
+		/usr/local/lib
+		/sw/lib
+		/opt/local/lib
+		${GLEW_ROOT_DIR}/lib
+		DOC "The GLEW library")
+ENDIF (WIN32)
+SET(GLEW_FOUND "NO")
+IF (GLEW_INCLUDE_PATH AND GLEW_LIBRARY)
+	SET(GLEW_LIBRARIES ${GLEW_LIBRARY})
+	SET(GLEW_FOUND "YES")
+ENDIF (GLEW_INCLUDE_PATH AND GLEW_LIBRARY)
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(GLEW DEFAULT_MSG GLEW_LIBRARY GLEW_INCLUDE_PATH)

--- a/cmake/modules/FindGLFW3.cmake
+++ b/cmake/modules/FindGLFW3.cmake
@@ -1,0 +1,47 @@
+# Locate the glfw3 library
+#
+# This module defines the following variables:
+#
+# GLFW3_LIBRARY the name of the library;
+# GLFW3_INCLUDE_DIR where to find glfw include files.
+# GLFW3_FOUND true if both the GLFW3_LIBRARY and GLFW3_INCLUDE_DIR have been found.
+#
+# To help locate the library and include file, you can define a
+# variable called GLFW3_ROOT which points to the root of the glfw library
+# installation.
+#
+# default search dirs
+# 
+# Cmake file from: https://github.com/daw42/glslcookbook
+
+set( _glfw3_HEADER_SEARCH_DIRS
+"/usr/include"
+"/usr/local/include"
+"C:/Program Files (x86)/glfw/include" )
+set( _glfw3_LIB_SEARCH_DIRS
+"/usr/lib"
+"/usr/local/lib"
+"C:/Program Files (x86)/glfw/lib-msvc110" )
+
+# Check environment for root search directory
+set( _glfw3_ENV_ROOT $ENV{GLFW3_ROOT} )
+if( NOT GLFW3_ROOT AND _glfw3_ENV_ROOT )
+	set(GLFW3_ROOT ${_glfw3_ENV_ROOT} )
+endif()
+
+# Put user specified location at beginning of search
+if( GLFW3_ROOT )
+	list( INSERT _glfw3_HEADER_SEARCH_DIRS 0 "${GLFW3_ROOT}/include" )
+	list( INSERT _glfw3_LIB_SEARCH_DIRS 0 "${GLFW3_ROOT}/lib" )
+endif()
+
+# Search for the header
+FIND_PATH(GLFW3_INCLUDE_DIR "GLFW/glfw3.h"
+PATHS ${_glfw3_HEADER_SEARCH_DIRS} )
+
+# Search for the library
+FIND_LIBRARY(GLFW3_LIBRARY NAMES glfw3 glfw
+PATHS ${_glfw3_LIB_SEARCH_DIRS} )
+INCLUDE(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(GLFW3 DEFAULT_MSG
+GLFW3_LIBRARY GLFW3_INCLUDE_DIR)

--- a/cmake/modules/FindGLM.cmake
+++ b/cmake/modules/FindGLM.cmake
@@ -1,0 +1,56 @@
+# FindGLM - attempts to locate the glm matrix/vector library.
+#
+# This module defines the following variables (on success):
+# GLM_INCLUDE_DIRS - where to find glm/glm.hpp
+# GLM_FOUND - if the library was successfully located
+#
+# It is trying a few standard installation locations, but can be customized
+# with the following variables:
+# GLM_ROOT_DIR - root directory of a glm installation
+# Headers are expected to be found in either:
+# <GLM_ROOT_DIR>/glm/glm.hpp OR
+# <GLM_ROOT_DIR>/include/glm/glm.hpp
+# This variable can either be a cmake or environment
+# variable. Note however that changing the value
+# of the environment varible will NOT result in
+# re-running the header search and therefore NOT
+# adjust the variables set by this module.
+#=============================================================================
+# Copyright 2012 Carsten Neumann
+#
+# Distributed under the OSI-approved BSD License (the "License");
+# see accompanying file Copyright.txt for details.
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the License for more information.
+#=============================================================================
+# (To distribute this file outside of CMake, substitute the full
+# License text for the above reference.)
+# default search dirs
+
+SET(_glm_HEADER_SEARCH_DIRS
+"/usr/include"
+"/usr/local/include"
+"C:/Program Files (x86)/glm" )
+# check environment variable
+SET(_glm_ENV_ROOT_DIR "$ENV{GLM_ROOT_DIR}")
+IF(NOT GLM_ROOT_DIR AND _glm_ENV_ROOT_DIR)
+	SET(GLM_ROOT_DIR "${_glm_ENV_ROOT_DIR}")
+ENDIF(NOT GLM_ROOT_DIR AND _glm_ENV_ROOT_DIR)
+# put user specified location at beginning of search
+IF(GLM_ROOT_DIR)
+	SET(_glm_HEADER_SEARCH_DIRS "${GLM_ROOT_DIR}"
+	"${GLM_ROOT_DIR}/include"
+	${_glm_HEADER_SEARCH_DIRS})
+ENDIF(GLM_ROOT_DIR)
+# locate header
+FIND_PATH(GLM_INCLUDE_DIR "glm/glm.hpp"
+PATHS ${_glm_HEADER_SEARCH_DIRS})
+INCLUDE(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(GLM DEFAULT_MSG
+GLM_INCLUDE_DIR)
+IF(GLM_FOUND)
+	SET(GLM_INCLUDE_DIRS "${GLM_INCLUDE_DIR}")
+	MESSAGE(STATUS "GLM_INCLUDE_DIR = ${GLM_INCLUDE_DIR}")
+ENDIF(GLM_FOUND)

--- a/cmake/modules/FindSOIL.cmake
+++ b/cmake/modules/FindSOIL.cmake
@@ -1,0 +1,33 @@
+# - Locate SOIL library
+# This module defines
+# SOIL_LIBRARY, the name of the library to link against
+# SOIL_FOUND
+# SOIL_INCLUDE_DIR, where to find SOIL.h
+# To Adding search path, set SOIL_ROOT_DIR as follows
+# set(SOIL_ROOT_DIR "path/to/soil")
+# or launch cmake with -DSOIL_ROOT_DIR="/path/to/SOIL_ROOT_DIR".
+#
+# author: Kazunori Kimura
+# email : kazunori.abu@gmail.com
+find_path(SOIL_INCLUDE_DIR_TMP SOIL.h
+	HINTS ${SOIL_ROOT_DIR}
+	PATH_SUFFIXES include/SOIL SOIL include
+)
+if(${SOIL_INCLUDE_DIR_TMP} STREQUAL "SOIL_INCLUDE_DIR_TMP-NOTFOUND")
+	set(SOIL_INCLUDE_DIR ${SOIL_INCLUDE_DIR_TMP})
+else()
+	string(REGEX REPLACE "(.*)/SOIL" "\\1" SOIL_INCLUDE_DIR ${SOIL_INCLUDE_DIR_TMP})
+endif()
+
+find_library(SOIL_LIBRARY
+	NAMES SOIL
+	HINTS ${SOIL_ROOT_DIR}
+	PATH_SUFFIXES lib
+)
+
+unset(INCLUDE_SEARCH_PATH)
+unset(LIB_SEARCH_PATH)
+unset(SOIL_INCLUDE_DIR_TMP)
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(SOIL
+REQUIRED_VARS SOIL_LIBRARY SOIL_INCLUDE_DIR)


### PR DESCRIPTION
I added the Find*.cmake files that you mentioned from Reddit. Also, I found a bug that I didn't realize last night when I was testing the CMake build- the resources, textures, and shaders aren't being detected by the IDE since it isn't aware of the bin/ directory. This might only be an issue on Linux and its not a terribly huge deal since the binaries are still being built and all the programs that don't use external resources run fine. I just wanted to push these changes first before rearranging the build structure.

At the bottom of the CMakeLists.txt you'll notice
`file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/resources DESTINATION ${CMAKE_CURRENT_BINARY_DIR})`
This should allow the resources to be moved over to the binaries, but it still isn't being found by the IDE. So this means the CMake needs to be altered to point to the resources/textures/etc. I didn't try to fix it yet since I wanted to see your thoughts on these changes first.

Hopefully, some more Linux users can test this and we can get some feedback, but right now this should be good enough for Linux users to build and start playing around I think.

Oh, and I decapitalized the first `link_directories` for conceptual symmetry.