### PR TITLE
fixed Linux error with the gamma variable already being defined in mathcalls.h

### DIFF
--- a/src/5.advanced_lighting/2.gamma_correction/gamma_correction.cpp
+++ b/src/5.advanced_lighting/2.gamma_correction/gamma_correction.cpp
@@ -35,7 +35,7 @@ GLfloat deltaTime = 0.0f;
 GLfloat lastFrame = 0.0f;
 
 // Options
-GLboolean gamma = false;
+GLboolean gammaEnabled = false;
 
 // The MAIN function, from here we start our application and run our Game loop
 int main()
@@ -141,14 +141,14 @@ int main()
         glUniform3fv(glGetUniformLocation(shader.Program, "lightPositions"), 4, &lightPositions[0][0]);
         glUniform3fv(glGetUniformLocation(shader.Program, "lightColors"), 4, &lightColors[0][0]);
         glUniform3fv(glGetUniformLocation(shader.Program, "viewPos"), 1, &camera.Position[0]);
-        glUniform1i(glGetUniformLocation(shader.Program, "gamma"), gamma);
+        glUniform1i(glGetUniformLocation(shader.Program, "gamma"), gammaEnabled);
         // Floor
         glBindVertexArray(planeVAO);
-        glBindTexture(GL_TEXTURE_2D, gamma ? floorTextureGammaCorrected : floorTexture);
+        glBindTexture(GL_TEXTURE_2D, gammaEnabled ? floorTextureGammaCorrected : floorTexture);
         glDrawArrays(GL_TRIANGLES, 0, 6);
         glBindVertexArray(0);
 
-        std::cout << (gamma ? "Gamma enabled" : "Gamma disabled") << std::endl;
+        std::cout << (gammaEnabled ? "Gamma enabled" : "Gamma disabled") << std::endl;
 
         // Swap the buffers
         glfwSwapBuffers(window);
@@ -201,7 +201,7 @@ void Do_Movement()
 
     if (keys[GLFW_KEY_SPACE] && !keysPressed[GLFW_KEY_SPACE])
     {
-        gamma = !gamma;
+        gammaEnabled = !gammaEnabled;
         keysPressed[GLFW_KEY_SPACE] = true;
     }
 }


### PR DESCRIPTION
I got an error when trying to make the latest commit on Ubuntu 14.04. Apparently, the gamma variable is already defined in [mathcalls.h](https://gcc.gnu.org/ml/gcc-help/2001-03/msg00285/mathcalls.h) which is included when math.h is included. I had no idea, but after changing 'gamma' to 'gammaEnabled' I was able to build no problem.