### PR TITLE
Support for out-of-source builds.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,13 @@ Note that you still have to manually copy the required .DLL files from the /dlls
 
 ## Linux building
 First make sure you have CMake, Git, and GCC by typing as root (sudo) `apt-get install g++ cmake git` and then get the required packages:
-Using root (sudo) and type `apt-get install libsoil-dev libglm-dev libassimp-dev libglew-dev libglfw3-dev` . Next, run CMake (preferably CMake-gui). The source directory is LearnOpenGL and specify the build directory as LearnOpenGL/build. Creating the build directory within LearnOpenGL is important for linking to the resource files (it also will be ignored by Git). Hit configure and specify your compiler files (Unix Makefiles are recommended), resolve any missing directories or libraries, and then hit generate. Navigate to the build directory (`cd LearnOpenGL/build`) and type `make` in the terminal. This should generate the executables in the respective chapter folders. Note that using CodeBlocks or an IDE may have issues running the programs due to problems finding the shader and resource files, however it should still be able to generate the exectuables.
+Using root (sudo) and type `apt-get install libsoil-dev libglm-dev libassimp-dev libglew-dev libglfw3-dev` . Next, run CMake (preferably CMake-gui). The source directory is LearnOpenGL and specify the build directory as LearnOpenGL/build. Creating the build directory within LearnOpenGL is important for linking to the resource files (it also will be ignored by Git). Hit configure and specify your compiler files (Unix Makefiles are recommended), resolve any missing directories or libraries, and then hit generate. Navigate to the build directory (`cd LearnOpenGL/build`) and type `make` in the terminal. This should generate the executables in the respective chapter folders.
+
+Note that CodeBlocks or other IDEs may have issues running the programs due to problems finding the shader and resource files, however it should still be able to generate the exectuables. To work around this problem it is possible to set an environment variable to tell the tutorials where the resource files can be found. The environment variable is named LOGL_ROOT_PATH and may be set to the path to the root of the LearnOpenGL directory tree. For example:
+
+    `export LOGL_ROOT_PATH=/home/user/tutorials/LearmOpenGL`
+
+Running `ls $LOGL_ROOT_PATH` should list, among other things, this README file and the resources direcory.
 
 ## Mac OS X building
 Thanks to Stéphane le Boeuf, a Github fork was set up that successfully compiles on Mac OSX (and Linux as well); current CMake hasn't been adapted for Mac OSX yet.  The following command lines build the projects on Mac OSX:

--- a/includes/learnopengl/filesystem.h
+++ b/includes/learnopengl/filesystem.h
@@ -1,0 +1,49 @@
+#ifndef FILESYSTEM_H
+#define FILESYSTEM_H
+
+#include <string>
+
+class FileSystem
+{
+private:
+  typedef std::string (*Builder) (const std::string& path);
+
+public:
+  static std::string getPath(const std::string& path)
+  {
+    static std::string(*pathBuilder)(std::string const &) = getPathBuilder();
+    return (*pathBuilder)(path);
+  }
+
+private:
+  static std::string const & getRoot()
+  {
+    static char const * givenRoot {getenv("LOGL_ROOT_PATH")};
+    static std::string root {givenRoot != nullptr ? givenRoot : ""};
+    return root;
+  }
+
+  //static std::string(*foo (std::string const &)) getPathBuilder()
+  static Builder getPathBuilder()
+  {
+    if (getRoot() != "")
+      return &FileSystem::getPathRelativeRoot;
+    else
+      return &FileSystem::getPathRelativeBinary;
+  }
+
+  static std::string getPathRelativeRoot(const std::string& path)
+  {
+    return getRoot() + std::string("/") + path;
+  }
+
+  static std::string getPathRelativeBinary(const std::string& path)
+  {
+    return "../../../" + path;
+  }
+
+
+};
+
+// FILESYSTEM_H
+#endif

--- a/includes/learnopengl/model.h
+++ b/includes/learnopengl/model.h
@@ -31,7 +31,7 @@ public:
 
     /*  Functions   */
     // Constructor, expects a filepath to a 3D model.
-    Model(GLchar* path, bool gamma = false) : gammaCorrection(gamma)
+    Model(string const & path, bool gamma = false) : gammaCorrection(gamma)
     {
         this->loadModel(path);
     }

--- a/src/1.getting_started/4.textures/textures_combined.cpp
+++ b/src/1.getting_started/4.textures/textures_combined.cpp
@@ -12,7 +12,7 @@
 
 // Other includes
 #include <learnopengl/shader.h>
-
+#include <learnopengl/filesystem.h>
 
 // Function prototypes
 void key_callback(GLFWwindow* window, int key, int scancode, int action, int mode);
@@ -105,7 +105,9 @@ int main()
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     // Load, create texture and generate mipmaps
     int width, height;
-    unsigned char* image = SOIL_load_image("../../../resources/textures/container.jpg", &width, &height, 0, SOIL_LOAD_RGB);
+
+    unsigned char* image = SOIL_load_image(FileSystem::getPath("resources/textures/container.jpg").c_str(), &width, &height, 0, SOIL_LOAD_RGB);
+
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width, height, 0, GL_RGB, GL_UNSIGNED_BYTE, image);
     glGenerateMipmap(GL_TEXTURE_2D);
     SOIL_free_image_data(image);
@@ -122,7 +124,7 @@ int main()
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     // Load, create texture and generate mipmaps
-    image = SOIL_load_image("../../../resources/textures/awesomeface.png", &width, &height, 0, SOIL_LOAD_RGB);
+    image = SOIL_load_image(FileSystem::getPath("resources/textures/awesomeface.png").c_str(), &width, &height, 0, SOIL_LOAD_RGB);
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width, height, 0, GL_RGB, GL_UNSIGNED_BYTE, image);
     glGenerateMipmap(GL_TEXTURE_2D);
     SOIL_free_image_data(image);

--- a/src/1.getting_started/5.transformations/transformations.cpp
+++ b/src/1.getting_started/5.transformations/transformations.cpp
@@ -16,7 +16,7 @@
 
 // Other includes
 #include <learnopengl/shader.h>
-
+#include <learnopengl/filesystem.h>
 
 // Function prototypes
 void key_callback(GLFWwindow* window, int key, int scancode, int action, int mode);
@@ -109,7 +109,7 @@ int main()
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     // Load, create texture and generate mipmaps
     int width, height;
-    unsigned char* image = SOIL_load_image("../../../resources/textures/container.jpg", &width, &height, 0, SOIL_LOAD_RGB);
+    unsigned char* image = SOIL_load_image(FileSystem::getPath("resources/textures/container.jpg").c_str(), &width, &height, 0, SOIL_LOAD_RGB);
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width, height, 0, GL_RGB, GL_UNSIGNED_BYTE, image);
     glGenerateMipmap(GL_TEXTURE_2D);
     SOIL_free_image_data(image);
@@ -126,7 +126,7 @@ int main()
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     // Load, create texture and generate mipmaps
-    image = SOIL_load_image("../../../resources/textures/awesomeface.png", &width, &height, 0, SOIL_LOAD_RGB);
+    image = SOIL_load_image(FileSystem::getPath("resources/textures/awesomeface.png").c_str(), &width, &height, 0, SOIL_LOAD_RGB);
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width, height, 0, GL_RGB, GL_UNSIGNED_BYTE, image);
     glGenerateMipmap(GL_TEXTURE_2D);
     SOIL_free_image_data(image);

--- a/src/1.getting_started/6.coordinate_systems/coordinate_systems_multiple_objects.cpp
+++ b/src/1.getting_started/6.coordinate_systems/coordinate_systems_multiple_objects.cpp
@@ -16,7 +16,7 @@
 
 // Other includes
 #include <learnopengl/shader.h>
-
+#include <learnopengl/filesystem.h>
 
 // Function prototypes
 void key_callback(GLFWwindow* window, int key, int scancode, int action, int mode);
@@ -150,7 +150,7 @@ int main()
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     // Load, create texture and generate mipmaps
     int width, height;
-    unsigned char* image = SOIL_load_image("../../../resources/textures/container.jpg", &width, &height, 0, SOIL_LOAD_RGB);
+    unsigned char* image = SOIL_load_image(FileSystem::getPath("resources/textures/container.jpg").c_str(), &width, &height, 0, SOIL_LOAD_RGB);
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width, height, 0, GL_RGB, GL_UNSIGNED_BYTE, image);
     glGenerateMipmap(GL_TEXTURE_2D);
     SOIL_free_image_data(image);
@@ -167,7 +167,7 @@ int main()
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     // Load, create texture and generate mipmaps
-    image = SOIL_load_image("../../../resources/textures/awesomeface.png", &width, &height, 0, SOIL_LOAD_RGB);
+    image = SOIL_load_image(FileSystem::getPath("resources/textures/awesomeface.png").c_str(), &width, &height, 0, SOIL_LOAD_RGB);
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width, height, 0, GL_RGB, GL_UNSIGNED_BYTE, image);
     glGenerateMipmap(GL_TEXTURE_2D);
     SOIL_free_image_data(image);

--- a/src/1.getting_started/7.camera/camera_with_class.cpp
+++ b/src/1.getting_started/7.camera/camera_with_class.cpp
@@ -19,6 +19,7 @@
 
 // Other Libs
 #include <SOIL.h>
+#include <learnopengl/filesystem.h>
 
 // Properties
 GLuint screenWidth = 800, screenHeight = 600;
@@ -162,7 +163,7 @@ int main()
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     // Load, create texture and generate mipmaps
     int width, height;
-    unsigned char* image = SOIL_load_image("../../../resources/textures/container.jpg", &width, &height, 0, SOIL_LOAD_RGB); 
+    unsigned char* image = SOIL_load_image(FileSystem::getPath("resources/textures/container.jpg").c_str(), &width, &height, 0, SOIL_LOAD_RGB);
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width, height, 0, GL_RGB, GL_UNSIGNED_BYTE, image);
     glGenerateMipmap(GL_TEXTURE_2D);
     SOIL_free_image_data(image);
@@ -177,7 +178,7 @@ int main()
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     // Load, create texture and generate mipmaps
-    image = SOIL_load_image("../../../resources/textures/awesomeface.png", &width, &height, 0, SOIL_LOAD_RGB); 
+    image = SOIL_load_image(FileSystem::getPath("resources/textures/awesomeface.png").c_str(), &width, &height, 0, SOIL_LOAD_RGB);
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width, height, 0, GL_RGB, GL_UNSIGNED_BYTE, image);
     glGenerateMipmap(GL_TEXTURE_2D);
     SOIL_free_image_data(image);

--- a/src/2.lighting/4.lighting_maps/lighting_maps_specular.cpp
+++ b/src/2.lighting/4.lighting_maps/lighting_maps_specular.cpp
@@ -18,7 +18,7 @@
 // Other includes
 #include <learnopengl/shader.h>
 #include <learnopengl/camera.h>
-
+#include <learnopengl/filesystem.h>
 
 // Function prototypes
 void key_callback(GLFWwindow* window, int key, int scancode, int action, int mode);
@@ -163,7 +163,7 @@ int main()
     int width, height;
     unsigned char* image;
     // Diffuse map
-    image = SOIL_load_image("../../../resources/textures/container2.png", &width, &height, 0, SOIL_LOAD_RGB);
+    image = SOIL_load_image(FileSystem::getPath("resources/textures/container2.png").c_str(), &width, &height, 0, SOIL_LOAD_RGB);
     glBindTexture(GL_TEXTURE_2D, diffuseMap);
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width, height, 0, GL_RGB, GL_UNSIGNED_BYTE, image);
     glGenerateMipmap(GL_TEXTURE_2D);
@@ -173,7 +173,7 @@ int main()
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST_MIPMAP_NEAREST);
     // Specular map
-    image = SOIL_load_image("../../../resources/textures/container2_specular.png", &width, &height, 0, SOIL_LOAD_RGB);
+    image = SOIL_load_image(FileSystem::getPath("resources/textures/container2_specular.png").c_str(), &width, &height, 0, SOIL_LOAD_RGB);
     glBindTexture(GL_TEXTURE_2D, specularMap);
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width, height, 0, GL_RGB, GL_UNSIGNED_BYTE, image);
     glGenerateMipmap(GL_TEXTURE_2D);

--- a/src/2.lighting/5.light_casters/light_casters_spotlight_soft.cpp
+++ b/src/2.lighting/5.light_casters/light_casters_spotlight_soft.cpp
@@ -18,7 +18,7 @@
 // Other includes
 #include <learnopengl/shader.h>
 #include <learnopengl/camera.h>
-
+#include <learnopengl/filesystem.h>
 
 // Function prototypes
 void key_callback(GLFWwindow* window, int key, int scancode, int action, int mode);
@@ -176,7 +176,7 @@ int main()
     int width, height;
     unsigned char* image;
     // Diffuse map
-    image = SOIL_load_image("../../../resources/textures/container2.png", &width, &height, 0, SOIL_LOAD_RGB);
+    image = SOIL_load_image(FileSystem::getPath("resources/textures/container2.png").c_str(), &width, &height, 0, SOIL_LOAD_RGB);
     glBindTexture(GL_TEXTURE_2D, diffuseMap);
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width, height, 0, GL_RGB, GL_UNSIGNED_BYTE, image);
     glGenerateMipmap(GL_TEXTURE_2D);
@@ -186,7 +186,7 @@ int main()
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST_MIPMAP_NEAREST);
     // Specular map
-    image = SOIL_load_image("../../../resources/textures/container2_specular.png", &width, &height, 0, SOIL_LOAD_RGB);
+    image = SOIL_load_image(FileSystem::getPath("resources/textures/container2_specular.png").c_str(), &width, &height, 0, SOIL_LOAD_RGB);
     glBindTexture(GL_TEXTURE_2D, specularMap);
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width, height, 0, GL_RGB, GL_UNSIGNED_BYTE, image);
     glGenerateMipmap(GL_TEXTURE_2D);

--- a/src/2.lighting/6.multiple_lights/multiple_lights.cpp
+++ b/src/2.lighting/6.multiple_lights/multiple_lights.cpp
@@ -18,7 +18,7 @@
 // Other includes
 #include <learnopengl/shader.h>
 #include <learnopengl/camera.h>
-
+#include <learnopengl/filesystem.h>
 
 // Function prototypes
 void key_callback(GLFWwindow* window, int key, int scancode, int action, int mode);
@@ -183,7 +183,7 @@ int main()
     int width, height;
     unsigned char* image;
     // Diffuse map
-    image = SOIL_load_image("../../../resources/textures/container2.png", &width, &height, 0, SOIL_LOAD_RGB);
+    image = SOIL_load_image(FileSystem::getPath("resources/textures/container2.png").c_str(), &width, &height, 0, SOIL_LOAD_RGB);
     glBindTexture(GL_TEXTURE_2D, diffuseMap);
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width, height, 0, GL_RGB, GL_UNSIGNED_BYTE, image);
     glGenerateMipmap(GL_TEXTURE_2D);
@@ -193,7 +193,7 @@ int main()
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST_MIPMAP_NEAREST);
     // Specular map
-    image = SOIL_load_image("../../../resources/textures/container2_specular.png", &width, &height, 0, SOIL_LOAD_RGB);
+    image = SOIL_load_image(FileSystem::getPath("resources/textures/container2_specular.png").c_str(), &width, &height, 0, SOIL_LOAD_RGB);
     glBindTexture(GL_TEXTURE_2D, specularMap);
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width, height, 0, GL_RGB, GL_UNSIGNED_BYTE, image);
     glGenerateMipmap(GL_TEXTURE_2D);

--- a/src/3.model_loading/1.model_loading/model_rendered.cpp
+++ b/src/3.model_loading/1.model_loading/model_rendered.cpp
@@ -20,6 +20,7 @@
 
 // Other Libs
 #include <SOIL.h>
+#include <learnopengl/filesystem.h>
 
 // Properties
 GLuint screenWidth = 800, screenHeight = 600;
@@ -74,8 +75,8 @@ int main()
     Shader shader("shader.vs", "shader.frag");
 
     // Load models
-    Model ourModel("../../../resources/objects/nanosuit/nanosuit.obj");
-    
+    Model ourModel(FileSystem::getPath("resources/objects/nanosuit/nanosuit.obj").c_str());
+
     // Draw in wireframe
     //glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
 

--- a/src/4.advanced_opengl/1.depth_testing/depth_testing_func.cpp
+++ b/src/4.advanced_opengl/1.depth_testing/depth_testing_func.cpp
@@ -19,6 +19,7 @@
 
 // Other Libs
 #include <SOIL.h>
+#include <learnopengl/filesystem.h>
 
 // Properties
 GLuint screenWidth = 800, screenHeight = 600;
@@ -28,7 +29,7 @@ void key_callback(GLFWwindow* window, int key, int scancode, int action, int mod
 void scroll_callback(GLFWwindow* window, double xoffset, double yoffset);
 void mouse_callback(GLFWwindow* window, double xpos, double ypos);
 void Do_Movement();
-GLuint loadTexture(GLchar* path);
+GLuint loadTexture(GLchar const * path);
 
 // Camera
 Camera camera(glm::vec3(0.0f, 0.0f, 3.0f));
@@ -156,8 +157,8 @@ int main()
     glBindVertexArray(0);
 
     // Load textures
-    GLuint cubeTexture = loadTexture("../../../resources/textures/marble.jpg");
-    GLuint floorTexture = loadTexture("../../../resources/textures/metal.png");
+    GLuint cubeTexture = loadTexture(FileSystem::getPath("resources/textures/marble.jpg").c_str());
+    GLuint floorTexture = loadTexture(FileSystem::getPath("resources/textures/metal.png").c_str());
     #pragma endregion
 
     // Game loop
@@ -213,7 +214,7 @@ int main()
 // This function loads a texture from file. Note: texture loading functions like these are usually 
 // managed by a 'Resource Manager' that manages all resources (like textures, models, audio). 
 // For learning purposes we'll just define it as a utility function.
-GLuint loadTexture(GLchar* path)
+GLuint loadTexture(GLchar const * path)
 {
     //Generate texture ID and load texture data 
     GLuint textureID;

--- a/src/4.advanced_opengl/10.instancing/instancing_asteroids_instanced.cpp
+++ b/src/4.advanced_opengl/10.instancing/instancing_asteroids_instanced.cpp
@@ -15,6 +15,8 @@
 #include <glm/gtc/matrix_transform.hpp>
 #include <glm/gtc/type_ptr.hpp>
 
+#include <learnopengl/filesystem.h>
+
 // Properties
 GLuint screenWidth = 800, screenHeight = 600;
 
@@ -67,8 +69,8 @@ int main()
     Shader instanceShader("instanced_asteroids.vs", "instanced_asteroids.frag");
 
     // Load models
-    Model rock("../../../resources/objects/rock/rock.obj");
-    Model planet("../../../resources/objects/planet/planet.obj");
+    Model rock(FileSystem::getPath("resources/objects/rock/rock.obj").c_str());
+    Model planet(FileSystem::getPath("resources/objects/planet/planet.obj").c_str());
 
     // Set projection matrix
     glm::mat4 projection = glm::perspective(45.0f, (GLfloat)screenWidth/(GLfloat)screenHeight, 1.0f, 10000.0f);

--- a/src/4.advanced_opengl/2.stencil_testing/stencil_testing.cpp
+++ b/src/4.advanced_opengl/2.stencil_testing/stencil_testing.cpp
@@ -19,6 +19,7 @@
 
 // Other Libs
 #include <SOIL.h>
+#include <learnopengl/filesystem.h>
 
 // Properties
 GLuint screenWidth = 800, screenHeight = 600;
@@ -28,7 +29,7 @@ void key_callback(GLFWwindow* window, int key, int scancode, int action, int mod
 void scroll_callback(GLFWwindow* window, double xoffset, double yoffset);
 void mouse_callback(GLFWwindow* window, double xpos, double ypos);
 void Do_Movement();
-GLuint loadTexture(GLchar* path);
+GLuint loadTexture(GLchar const * path);
 
 // Camera
 Camera camera(glm::vec3(0.0f, 0.0f, 3.0f));
@@ -160,8 +161,8 @@ int main()
     glBindVertexArray(0);
 
     // Load textures
-    GLuint cubeTexture = loadTexture("../../../resources/textures/marble.jpg");
-    GLuint floorTexture = loadTexture("../../../resources/textures/metal.png");
+    GLuint cubeTexture = loadTexture(FileSystem::getPath("resources/textures/marble.jpg").c_str());
+    GLuint floorTexture = loadTexture(FileSystem::getPath("resources/textures/metal.png").c_str());
     #pragma endregion
 
     // Game loop
@@ -260,7 +261,7 @@ void DrawScene()
 // This function loads a texture from file. Note: texture loading functions like these are usually 
 // managed by a 'Resource Manager' that manages all resources (like textures, models, audio). 
 // For learning purposes we'll just define it as a utility function.
-GLuint loadTexture(GLchar* path)
+GLuint loadTexture(GLchar const * path)
 {
     //Generate texture ID and load texture data 
     GLuint textureID;

--- a/src/4.advanced_opengl/3.1.blending_discard/blending_discard.cpp
+++ b/src/4.advanced_opengl/3.1.blending_discard/blending_discard.cpp
@@ -19,6 +19,7 @@
 
 // Other Libs
 #include <SOIL.h>
+#include <learnopengl/filesystem.h>
 
 // Properties
 GLuint screenWidth = 800, screenHeight = 600;
@@ -28,7 +29,7 @@ void key_callback(GLFWwindow* window, int key, int scancode, int action, int mod
 void scroll_callback(GLFWwindow* window, double xoffset, double yoffset);
 void mouse_callback(GLFWwindow* window, double xpos, double ypos);
 void Do_Movement();
-GLuint loadTexture(GLchar* path, GLboolean alpha = false);
+GLuint loadTexture(GLchar const * path, GLboolean alpha = false);
 
 // Camera
 Camera camera(glm::vec3(0.0f, 0.0f, 3.0f));
@@ -177,9 +178,9 @@ int main()
     glBindVertexArray(0);
 
     // Load textures
-    GLuint cubeTexture = loadTexture("../../../resources/textures/marble.jpg");
-    GLuint floorTexture = loadTexture("../../../resources/textures/metal.png");
-    GLuint transparentTexture = loadTexture("../../../resources/textures/grass.png", true);
+    GLuint cubeTexture = loadTexture(FileSystem::getPath("resources/textures/marble.jpg").c_str());
+    GLuint floorTexture = loadTexture(FileSystem::getPath("resources/textures/metal.png").c_str());
+    GLuint transparentTexture = loadTexture(FileSystem::getPath("resources/textures/grass.png").c_str(), true);
 #pragma endregion
 
     std::vector<glm::vec3> vegetation;
@@ -252,7 +253,7 @@ int main()
 // This function loads a texture from file. Note: texture loading functions like these are usually 
 // managed by a 'Resource Manager' that manages all resources (like textures, models, audio). 
 // For learning purposes we'll just define it as a utility function.
-GLuint loadTexture(GLchar* path, GLboolean alpha)
+GLuint loadTexture(GLchar const * path, GLboolean alpha)
 {
     //Generate texture ID and load texture data 
     GLuint textureID;

--- a/src/4.advanced_opengl/3.2.blending_sort/blending_sorted.cpp
+++ b/src/4.advanced_opengl/3.2.blending_sort/blending_sorted.cpp
@@ -20,6 +20,7 @@
 
 // Other Libs
 #include <SOIL.h>
+#include <learnopengl/filesystem.h>
 
 // Properties
 GLuint screenWidth = 800, screenHeight = 600;
@@ -29,7 +30,7 @@ void key_callback(GLFWwindow* window, int key, int scancode, int action, int mod
 void scroll_callback(GLFWwindow* window, double xoffset, double yoffset);
 void mouse_callback(GLFWwindow* window, double xpos, double ypos);
 void Do_Movement();
-GLuint loadTexture(GLchar* path, GLboolean alpha = false);
+GLuint loadTexture(GLchar const * path, GLboolean alpha = false);
 
 // Camera
 Camera camera(glm::vec3(0.0f, 0.0f, 3.0f));
@@ -180,9 +181,9 @@ int main()
     glBindVertexArray(0);
 
     // Load textures
-    GLuint cubeTexture = loadTexture("../../../resources/textures/marble.jpg");
-    GLuint floorTexture = loadTexture("../../../resources/textures/metal.png");
-    GLuint transparentTexture = loadTexture("../../../resources/textures/window.png", true);
+    GLuint cubeTexture = loadTexture(FileSystem::getPath("resources/textures/marble.jpg").c_str());
+    GLuint floorTexture = loadTexture(FileSystem::getPath("resources/textures/metal.png").c_str());
+    GLuint transparentTexture = loadTexture(FileSystem::getPath("resources/textures/window.png").c_str(), true);
 #pragma endregion
 
     std::vector<glm::vec3> windows;
@@ -263,7 +264,7 @@ int main()
 // This function loads a texture from file. Note: texture loading functions like these are usually 
 // managed by a 'Resource Manager' that manages all resources (like textures, models, audio). 
 // For learning purposes we'll just define it as a utility function.
-GLuint loadTexture(GLchar* path, GLboolean alpha)
+GLuint loadTexture(GLchar const * path, GLboolean alpha)
 {
     //Generate texture ID and load texture data 
     GLuint textureID;

--- a/src/4.advanced_opengl/5.framebuffers/framebuffers_screen_texture.cpp
+++ b/src/4.advanced_opengl/5.framebuffers/framebuffers_screen_texture.cpp
@@ -21,6 +21,7 @@ using namespace std;
 
 // Other Libs
 #include <SOIL.h>
+#include <learnopengl/filesystem.h>
 
 // Properties
 GLuint screenWidth = 800, screenHeight = 600;
@@ -30,7 +31,7 @@ void key_callback(GLFWwindow* window, int key, int scancode, int action, int mod
 void scroll_callback(GLFWwindow* window, double xoffset, double yoffset);
 void mouse_callback(GLFWwindow* window, double xpos, double ypos);
 void Do_Movement();
-GLuint loadTexture(GLchar* path, GLboolean alpha = false);
+GLuint loadTexture(GLchar const * path, GLboolean alpha = false);
 GLuint generateAttachmentTexture(GLboolean depth, GLboolean stencil);
 
 // Camera
@@ -182,8 +183,8 @@ int main()
     glBindVertexArray(0);
 
     // Load textures
-    GLuint cubeTexture = loadTexture("../../../resources/textures/container.jpg");
-    GLuint floorTexture = loadTexture("../../../resources/textures/metal.png");
+    GLuint cubeTexture = loadTexture(FileSystem::getPath("resources/textures/container.jpg").c_str());
+    GLuint floorTexture = loadTexture(FileSystem::getPath("resources/textures/metal.png").c_str());
     #pragma endregion
 
     // Framebuffers
@@ -291,7 +292,7 @@ int main()
 // This function loads a texture from file. Note: texture loading functions like these are usually 
 // managed by a 'Resource Manager' that manages all resources (like textures, models, audio). 
 // For learning purposes we'll just define it as a utility function.
-GLuint loadTexture(GLchar* path, GLboolean alpha)
+GLuint loadTexture(GLchar const * path, GLboolean alpha)
 {
     //Generate texture ID and load texture data 
     GLuint textureID;

--- a/src/4.advanced_opengl/6.cubemaps/cubemaps_skybox_optimized.cpp
+++ b/src/4.advanced_opengl/6.cubemaps/cubemaps_skybox_optimized.cpp
@@ -21,6 +21,7 @@ using namespace std;
 
 // Other Libs
 #include <SOIL.h>
+#include <learnopengl/filesystem.h>
 
 // Properties
 GLuint screenWidth = 800, screenHeight = 600;
@@ -30,7 +31,7 @@ void key_callback(GLFWwindow* window, int key, int scancode, int action, int mod
 void scroll_callback(GLFWwindow* window, double xoffset, double yoffset);
 void mouse_callback(GLFWwindow* window, double xpos, double ypos);
 void Do_Movement();
-GLuint loadTexture(GLchar* path);
+GLuint loadTexture(GLchar const * path);
 GLuint loadCubemap(std::vector<const GLchar*> faces);
 
 // Camera
@@ -198,12 +199,12 @@ int main()
 
     // Cubemap (Skybox)
     std::vector<const GLchar*> faces;
-    faces.push_back("../../../resources/textures/skybox/right.jpg");
-    faces.push_back("../../../resources/textures/skybox/left.jpg");
-    faces.push_back("../../../resources/textures/skybox/top.jpg");
-    faces.push_back("../../../resources/textures/skybox/bottom.jpg");
-    faces.push_back("../../../resources/textures/skybox/back.jpg");
-    faces.push_back("../../../resources/textures/skybox/front.jpg");
+    faces.push_back(FileSystem::getPath("resources/textures/skybox/right.jpg").c_str());
+    faces.push_back(FileSystem::getPath("resources/textures/skybox/left.jpg").c_str());
+    faces.push_back(FileSystem::getPath("resources/textures/skybox/top.jpg").c_str());
+    faces.push_back(FileSystem::getPath("resources/textures/skybox/bottom.jpg").c_str());
+    faces.push_back(FileSystem::getPath("resources/textures/skybox/back.jpg").c_str());
+    faces.push_back(FileSystem::getPath("resources/textures/skybox/front.jpg").c_str());
     GLuint skyboxTexture = loadCubemap(faces);
 
     // Draw as wireframe
@@ -300,7 +301,7 @@ GLuint loadCubemap(std::vector<const GLchar*> faces)
 // This function loads a texture from file. Note: texture loading functions like these are usually 
 // managed by a 'Resource Manager' that manages all resources (like textures, models, audio). 
 // For learning purposes we'll just define it as a utility function.
-GLuint loadTexture(GLchar* path)
+GLuint loadTexture(GLchar const * path)
 {
     //Generate texture ID and load texture data 
     GLuint textureID;

--- a/src/5.advanced_lighting/1.advanced_lighting/advanced_lighting.cpp
+++ b/src/5.advanced_lighting/1.advanced_lighting/advanced_lighting.cpp
@@ -16,6 +16,7 @@
 
 // Other Libs
 #include <SOIL.h>
+#include <learnopengl/filesystem.h>
 
 // Properties
 const GLuint SCR_WIDTH = 800, SCR_HEIGHT = 600;
@@ -25,7 +26,7 @@ void key_callback(GLFWwindow* window, int key, int scancode, int action, int mod
 void scroll_callback(GLFWwindow* window, double xoffset, double yoffset);
 void mouse_callback(GLFWwindow* window, double xpos, double ypos);
 void Do_Movement();
-GLuint loadTexture(GLchar* path);
+GLuint loadTexture(GLchar const * path);
 
 // Camera
 Camera camera(glm::vec3(0.0f, 0.0f, 3.0f));
@@ -100,7 +101,7 @@ int main()
     glm::vec3 lightPos(0.0f, 0.0f, 0.0f);
 
     // Load textures
-    GLuint floorTexture = loadTexture("../../../resources/textures/wood.png");
+    GLuint floorTexture = loadTexture(FileSystem::getPath("resources/textures/wood.png").c_str());
 
     // Game loop
     while(!glfwWindowShouldClose(window))
@@ -147,7 +148,7 @@ int main()
 // This function loads a texture from file. Note: texture loading functions like these are usually 
 // managed by a 'Resource Manager' that manages all resources (like textures, models, audio). 
 // For learning purposes we'll just define it as a utility function.
-GLuint loadTexture(GLchar* path)
+GLuint loadTexture(GLchar const * path)
 {
     // Generate texture ID and load texture data 
     GLuint textureID;

--- a/src/5.advanced_lighting/2.gamma_correction/gamma_correction.cpp
+++ b/src/5.advanced_lighting/2.gamma_correction/gamma_correction.cpp
@@ -16,6 +16,7 @@
 
 // Other Libs
 #include <SOIL.h>
+#include <learnopengl/filesystem.h>
 
 // Properties
 const GLuint SCR_WIDTH = 800, SCR_HEIGHT = 600;
@@ -25,7 +26,7 @@ void key_callback(GLFWwindow* window, int key, int scancode, int action, int mod
 void scroll_callback(GLFWwindow* window, double xoffset, double yoffset);
 void mouse_callback(GLFWwindow* window, double xpos, double ypos);
 void Do_Movement();
-GLuint loadTexture(GLchar* path, bool gammaCorrection);
+GLuint loadTexture(GLchar const * path, bool gammaCorrection);
 
 // Camera
 Camera camera(glm::vec3(0.0f, 0.0f, 3.0f));
@@ -112,8 +113,8 @@ int main()
     };
 
     // Load textures
-    GLuint floorTexture = loadTexture("../../../resources/textures/wood.png", false);
-    GLuint floorTextureGammaCorrected = loadTexture("../../../resources/textures/wood.png", true);
+    GLuint floorTexture = loadTexture(FileSystem::getPath("resources/textures/wood.png").c_str(), false);
+    GLuint floorTextureGammaCorrected = loadTexture(FileSystem::getPath("resources/textures/wood.png").c_str(), true);
 
     // Game loop
     while (!glfwWindowShouldClose(window))
@@ -161,7 +162,7 @@ int main()
 // This function loads a texture from file. Note: texture loading functions like these are usually 
 // managed by a 'Resource Manager' that manages all resources (like textures, models, audio). 
 // For learning purposes we'll just define it as a utility function.
-GLuint loadTexture(GLchar* path, bool gammaCorrection)
+GLuint loadTexture(GLchar const * path, bool gammaCorrection)
 {
     // Generate texture ID and load texture data 
     GLuint textureID;

--- a/src/5.advanced_lighting/3.1.shadow_mapping/shadow_mapping.cpp
+++ b/src/5.advanced_lighting/3.1.shadow_mapping/shadow_mapping.cpp
@@ -16,6 +16,7 @@
 
 // Other Libs
 #include <SOIL.h>
+#include <learnopengl/filesystem.h>
 
 // Properties
 const GLuint SCR_WIDTH = 800, SCR_HEIGHT = 600;
@@ -25,7 +26,7 @@ void key_callback(GLFWwindow* window, int key, int scancode, int action, int mod
 void scroll_callback(GLFWwindow* window, double xoffset, double yoffset);
 void mouse_callback(GLFWwindow* window, double xpos, double ypos);
 void Do_Movement();
-GLuint loadTexture(GLchar* path);
+GLuint loadTexture(GLchar const * path);
 void RenderScene(Shader &shader);
 void RenderCube();
 void RenderQuad();
@@ -90,7 +91,7 @@ int main()
          25.0f, -0.5f,  25.0f,  0.0f,  1.0f,  0.0f,  25.0f, 0.0f,
         -25.0f, -0.5f, -25.0f,  0.0f,  1.0f,  0.0f,  0.0f,  25.0f,
         -25.0f, -0.5f,  25.0f,  0.0f,  1.0f,  0.0f,  0.0f,  0.0f,
- 
+
          25.0f, -0.5f,  25.0f,  0.0f,  1.0f,  0.0f,  25.0f, 0.0f,
          25.0f, -0.5f, -25.0f,  0.0f,  1.0f,  0.0f,  25.0f, 25.0f,
         -25.0f, -0.5f, -25.0f,  0.0f,  1.0f,  0.0f,  0.0f,  25.0f
@@ -114,7 +115,7 @@ int main()
     glm::vec3 lightPos(-2.0f, 4.0f, -1.0f);
 
     // Load textures
-    woodTexture = loadTexture("../../../resources/textures/wood.png");
+    woodTexture = loadTexture(FileSystem::getPath("resources/textures/wood.png").c_str());
 
     // Configure depth map FBO
     const GLuint SHADOW_WIDTH = 1024, SHADOW_HEIGHT = 1024;
@@ -128,7 +129,7 @@ int main()
     glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT, SHADOW_WIDTH, SHADOW_HEIGHT, 0, GL_DEPTH_COMPONENT, GL_FLOAT, NULL);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER); 
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER);
     GLfloat borderColor[] = { 1.0, 1.0, 1.0, 1.0 };
     glTexParameterfv(GL_TEXTURE_2D, GL_TEXTURE_BORDER_COLOR, borderColor);
@@ -174,7 +175,7 @@ int main()
             RenderScene(simpleDepthShader);
         glBindFramebuffer(GL_FRAMEBUFFER, 0);
 
-        // 2. Render scene as normal 
+        // 2. Render scene as normal
         glViewport(0, 0, SCR_WIDTH, SCR_HEIGHT);
         glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
         shader.Use();
@@ -201,7 +202,7 @@ int main()
         glActiveTexture(GL_TEXTURE0);
         glBindTexture(GL_TEXTURE_2D, depthMap);
         //RenderQuad(); // uncomment this line to see depth map
-        
+
 
         // Swap the buffers
         glfwSwapBuffers(window);
@@ -216,7 +217,7 @@ void RenderScene(Shader &shader)
     // Floor
     glm::mat4 model;
     glUniformMatrix4fv(glGetUniformLocation(shader.Program, "model"), 1, GL_FALSE, glm::value_ptr(model));
-    glBindVertexArray(planeVAO);    
+    glBindVertexArray(planeVAO);
     glDrawArrays(GL_TRIANGLES, 0, 6);
     glBindVertexArray(0);
     // Cubes
@@ -280,7 +281,7 @@ void RenderCube()
             // Back face
             -0.5f, -0.5f, -0.5f, 0.0f, 0.0f, -1.0f, 0.0f, 0.0f, // Bottom-left
             0.5f, 0.5f, -0.5f, 0.0f, 0.0f, -1.0f, 1.0f, 1.0f, // top-right
-            0.5f, -0.5f, -0.5f, 0.0f, 0.0f, -1.0f, 1.0f, 0.0f, // bottom-right         
+            0.5f, -0.5f, -0.5f, 0.0f, 0.0f, -1.0f, 1.0f, 0.0f, // bottom-right
             0.5f, 0.5f, -0.5f, 0.0f, 0.0f, -1.0f, 1.0f, 1.0f,  // top-right
             -0.5f, -0.5f, -0.5f, 0.0f, 0.0f, -1.0f, 0.0f, 0.0f,  // bottom-left
             -0.5f, 0.5f, -0.5f, 0.0f, 0.0f, -1.0f, 0.0f, 1.0f,// top-left
@@ -301,10 +302,10 @@ void RenderCube()
             // Right face
             0.5f, 0.5f, 0.5f, 1.0f, 0.0f, 0.0f, 1.0f, 0.0f, // top-left
             0.5f, -0.5f, -0.5f, 1.0f, 0.0f, 0.0f, 0.0f, 1.0f, // bottom-right
-            0.5f, 0.5f, -0.5f, 1.0f, 0.0f, 0.0f, 1.0f, 1.0f, // top-right         
+            0.5f, 0.5f, -0.5f, 1.0f, 0.0f, 0.0f, 1.0f, 1.0f, // top-right
             0.5f, -0.5f, -0.5f, 1.0f, 0.0f, 0.0f, 0.0f, 1.0f,  // bottom-right
             0.5f, 0.5f, 0.5f, 1.0f, 0.0f, 0.0f, 1.0f, 0.0f,  // top-left
-            0.5f, -0.5f, 0.5f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, // bottom-left     
+            0.5f, -0.5f, 0.5f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, // bottom-left
             // Bottom face
             -0.5f, -0.5f, -0.5f, 0.0f, -1.0f, 0.0f, 0.0f, 1.0f, // top-right
             0.5f, -0.5f, -0.5f, 0.0f, -1.0f, 0.0f, 1.0f, 1.0f, // top-left
@@ -315,10 +316,10 @@ void RenderCube()
             // Top face
             -0.5f, 0.5f, -0.5f, 0.0f, 1.0f, 0.0f, 0.0f, 1.0f,// top-left
             0.5f, 0.5f, 0.5f, 0.0f, 1.0f, 0.0f, 1.0f, 0.0f, // bottom-right
-            0.5f, 0.5f, -0.5f, 0.0f, 1.0f, 0.0f, 1.0f, 1.0f, // top-right     
+            0.5f, 0.5f, -0.5f, 0.0f, 1.0f, 0.0f, 1.0f, 1.0f, // top-right
             0.5f, 0.5f, 0.5f, 0.0f, 1.0f, 0.0f, 1.0f, 0.0f, // bottom-right
             -0.5f, 0.5f, -0.5f, 0.0f, 1.0f, 0.0f, 0.0f, 1.0f,// top-left
-            -0.5f, 0.5f, 0.5f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f // bottom-left        
+            -0.5f, 0.5f, 0.5f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f // bottom-left
         };
         glGenVertexArrays(1, &cubeVAO);
         glGenBuffers(1, &cubeVBO);
@@ -342,12 +343,12 @@ void RenderCube()
     glBindVertexArray(0);
 }
 
-// This function loads a texture from file. Note: texture loading functions like these are usually 
-// managed by a 'Resource Manager' that manages all resources (like textures, models, audio). 
+// This function loads a texture from file. Note: texture loading functions like these are usually
+// managed by a 'Resource Manager' that manages all resources (like textures, models, audio).
 // For learning purposes we'll just define it as a utility function.
-GLuint loadTexture(GLchar* path)
+GLuint loadTexture(GLchar const * path)
 {
-    // Generate texture ID and load texture data 
+    // Generate texture ID and load texture data
     GLuint textureID;
     glGenTextures(1, &textureID);
     int width, height;

--- a/src/5.advanced_lighting/3.2.point_shadows/point_shadows.cpp
+++ b/src/5.advanced_lighting/3.2.point_shadows/point_shadows.cpp
@@ -16,6 +16,7 @@
 
 // Other Libs
 #include <SOIL.h>
+#include <learnopengl/filesystem.h>
 
 // Properties
 const GLuint SCR_WIDTH = 800, SCR_HEIGHT = 600;
@@ -25,7 +26,7 @@ void key_callback(GLFWwindow* window, int key, int scancode, int action, int mod
 void scroll_callback(GLFWwindow* window, double xoffset, double yoffset);
 void mouse_callback(GLFWwindow* window, double xpos, double ypos);
 void Do_Movement();
-GLuint loadTexture(GLchar* path);
+GLuint loadTexture(GLchar const * path);
 void RenderScene(Shader &shader);
 void RenderCube();
 void RenderQuad();
@@ -89,7 +90,7 @@ int main()
     glm::vec3 lightPos(0.0f, 0.0f, 0.0f);
 
     // Load textures
-    woodTexture = loadTexture("../../../resources/textures/wood.png");
+    woodTexture = loadTexture(FileSystem::getPath("resources/textures/wood.png").c_str());
 
     // Configure depth map FBO
     const GLuint SHADOW_WIDTH = 1024, SHADOW_HEIGHT = 1024;
@@ -300,7 +301,7 @@ void RenderCube()
 // This function loads a texture from file. Note: texture loading functions like these are usually 
 // managed by a 'Resource Manager' that manages all resources (like textures, models, audio). 
 // For learning purposes we'll just define it as a utility function.
-GLuint loadTexture(GLchar* path)
+GLuint loadTexture(GLchar const * path)
 {
     // Generate texture ID and load texture data 
     GLuint textureID;

--- a/src/5.advanced_lighting/3.3.csm/csm.cpp
+++ b/src/5.advanced_lighting/3.3.csm/csm.cpp
@@ -28,7 +28,7 @@ void key_callback(GLFWwindow* window, int key, int scancode, int action, int mod
 void scroll_callback(GLFWwindow* window, double xoffset, double yoffset);
 void mouse_callback(GLFWwindow* window, double xpos, double ypos);
 void Do_Movement();
-GLuint loadTexture(GLchar* path);
+GLuint loadTexture(GLchar const * path);
 
 // Camera
 Camera camera(glm::vec3(0.0f, 0.0f, 3.0f));
@@ -156,8 +156,8 @@ int main()
     glBindVertexArray(0);
 
     // Load textures
-    GLuint cubeTexture = loadTexture("../../../resources/textures/marble.jpg");
-    GLuint floorTexture = loadTexture("../../../resources/textures/metal.png");
+    GLuint cubeTexture = loadTexture(FileSystem::getPath("resources/textures/marble.jpg").c_str());
+    GLuint floorTexture = loadTexture(FileSystem::getPath("resources/textures/metal.png").c_str());
     #pragma endregion
 
     // Game loop
@@ -213,7 +213,7 @@ int main()
 // This function loads a texture from file. Note: texture loading functions like these are usually 
 // managed by a 'Resource Manager' that manages all resources (like textures, models, audio). 
 // For learning purposes we'll just define it as a utility function.
-GLuint loadTexture(GLchar* path)
+GLuint loadTexture(GLchar const * path)
 {
     //Generate texture ID and load texture data 
     GLuint textureID;

--- a/src/5.advanced_lighting/4.normal_mapping/normal_mapping.cpp
+++ b/src/5.advanced_lighting/4.normal_mapping/normal_mapping.cpp
@@ -20,6 +20,7 @@
 
 // Other Libs
 #include <SOIL.h>
+#include <learnopengl/filesystem.h>
 
 // Properties
 const GLuint SCR_WIDTH = 800, SCR_HEIGHT = 600;
@@ -29,7 +30,7 @@ void key_callback(GLFWwindow* window, int key, int scancode, int action, int mod
 void scroll_callback(GLFWwindow* window, double xoffset, double yoffset);
 void mouse_callback(GLFWwindow* window, double xpos, double ypos);
 void Do_Movement();
-GLuint loadTexture(GLchar* path);
+GLuint loadTexture(GLchar const * path);
 void RenderQuad();
 
 // Camera
@@ -73,8 +74,8 @@ int main()
     Shader shader("normal_mapping.vs", "normal_mapping.frag");
 
     // Load textures
-    GLuint diffuseMap = loadTexture("../../../resources/textures/brickwall.jpg");
-    GLuint normalMap = loadTexture("../../../resources/textures/brickwall_normal.jpg");
+    GLuint diffuseMap = loadTexture(FileSystem::getPath("resources/textures/brickwall.jpg").c_str());
+    GLuint normalMap = loadTexture(FileSystem::getPath("resources/textures/brickwall_normal.jpg").c_str());
 
     // Set texture units 
     shader.Use();
@@ -229,7 +230,7 @@ void RenderQuad()
 // This function loads a texture from file. Note: texture loading functions like these are usually 
 // managed by a 'Resource Manager' that manages all resources (like textures, models, audio). 
 // For learning purposes we'll just define it as a utility function.
-GLuint loadTexture(GLchar* path)
+GLuint loadTexture(GLchar const * path)
 {
     //Generate texture ID and load texture data 
     GLuint textureID;

--- a/src/5.advanced_lighting/5.parallax_mapping/parallax_mapping.cpp
+++ b/src/5.advanced_lighting/5.parallax_mapping/parallax_mapping.cpp
@@ -20,6 +20,7 @@
 
 // Other Libs
 #include <SOIL.h>
+#include <learnopengl/filesystem.h>
 
 // Properties
 const GLuint SCR_WIDTH = 800, SCR_HEIGHT = 600;
@@ -29,7 +30,7 @@ void key_callback(GLFWwindow* window, int key, int scancode, int action, int mod
 void scroll_callback(GLFWwindow* window, double xoffset, double yoffset);
 void mouse_callback(GLFWwindow* window, double xpos, double ypos);
 void Do_Movement();
-GLuint loadTexture(GLchar* path);
+GLuint loadTexture(GLchar const * path);
 void RenderQuad();
 
 // Camera
@@ -76,12 +77,12 @@ int main()
     Shader shader("parallax_mapping.vs", "parallax_mapping.frag");
 
     // Load textures
-    GLuint diffuseMap = loadTexture("../../../resources/textures/bricks2.jpg");
-	GLuint normalMap = loadTexture("../../../resources/textures/bricks2_normal.jpg");
-	GLuint heightMap = loadTexture("../../../resources/textures/bricks2_disp.jpg");
-    //GLuint diffuseMap = loadTexture("../../../resources/textures/wood.png");
-    //GLuint normalMap = loadTexture("../../../resources/textures/toy_box_normal.png");
-    //GLuint heightMap = loadTexture("../../../resources/textures/toy_box_disp.png");
+    GLuint diffuseMap = loadTexture(FileSystem::getPath("resources/textures/bricks2.jpg").c_str());
+	GLuint normalMap = loadTexture(FileSystem::getPath("resources/textures/bricks2_normal.jpg").c_str());
+	GLuint heightMap = loadTexture(FileSystem::getPath("resources/textures/bricks2_disp.jpg").c_str());
+    //GLuint diffuseMap = loadTexture(FileSystem::getPath("resources/textures/wood.png").c_str();
+    //GLuint normalMap = loadTexture(FileSystem::getPath("resources/textures/toy_box_normal.png").c_str());
+    //GLuint heightMap = loadTexture(FileSystem::getPath("resources/textures/toy_box_disp.png").c_str());
 
     // Set texture units 
     shader.Use();
@@ -241,7 +242,7 @@ void RenderQuad()
 // This function loads a texture from file. Note: texture loading functions like these are usually 
 // managed by a 'Resource Manager' that manages all resources (like textures, models, audio). 
 // For learning purposes we'll just define it as a utility function.
-GLuint loadTexture(GLchar* path)
+GLuint loadTexture(GLchar const * path)
 {
     //Generate texture ID and load texture data 
     GLuint textureID;

--- a/src/5.advanced_lighting/6.hdr/hdr.cpp
+++ b/src/5.advanced_lighting/6.hdr/hdr.cpp
@@ -16,6 +16,7 @@
 
 // Other Libs
 #include <SOIL.h>
+#include <learnopengl/filesystem.h>
 
 // Properties
 const GLuint SCR_WIDTH = 800, SCR_HEIGHT = 600;
@@ -25,7 +26,7 @@ void key_callback(GLFWwindow* window, int key, int scancode, int action, int mod
 void scroll_callback(GLFWwindow* window, double xoffset, double yoffset);
 void mouse_callback(GLFWwindow* window, double xpos, double ypos);
 void Do_Movement();
-GLuint loadTexture(GLchar* path);
+GLuint loadTexture(GLchar const * path);
 void RenderScene(Shader &shader);
 void RenderCube();
 void RenderQuad();
@@ -94,7 +95,7 @@ int main()
     lightColors.push_back(glm::vec3(0.0f, 0.1f, 0.0f));
 
     // Load textures
-    woodTexture = loadTexture("../../../resources/textures/wood.png");
+    woodTexture = loadTexture(FileSystem::getPath("resources/textures/wood.png").c_str());
 
     // Set up floating point framebuffer to render scene to
     GLuint hdrFBO;
@@ -288,7 +289,7 @@ void RenderCube()
 // This function loads a texture from file. Note: texture loading functions like these are usually 
 // managed by a 'Resource Manager' that manages all resources (like textures, models, audio). 
 // For learning purposes we'll just define it as a utility function.
-GLuint loadTexture(GLchar* path)
+GLuint loadTexture(GLchar const * path)
 {
     // Generate texture ID and load texture data 
     GLuint textureID;

--- a/src/5.advanced_lighting/7.bloom/bloom.cpp
+++ b/src/5.advanced_lighting/7.bloom/bloom.cpp
@@ -16,6 +16,7 @@
 
 // Other Libs
 #include <SOIL.h>
+#include <learnopengl/filesystem.h>
 
 // Properties
 const GLuint SCR_WIDTH = 800, SCR_HEIGHT = 600;
@@ -25,7 +26,7 @@ void key_callback(GLFWwindow* window, int key, int scancode, int action, int mod
 void scroll_callback(GLFWwindow* window, double xoffset, double yoffset);
 void mouse_callback(GLFWwindow* window, double xpos, double ypos);
 void Do_Movement();
-GLuint loadTexture(GLchar* path);
+GLuint loadTexture(GLchar const * path);
 void RenderScene(Shader &shader);
 void RenderCube();
 void RenderQuad();
@@ -98,8 +99,8 @@ int main()
 	lightColors.push_back(glm::vec3(0.0f, 1.5f, 0.0f));
 
 	// Load textures
-	GLuint woodTexture      = loadTexture("../../../resources/textures/wood.png");
-	GLuint containerTexture = loadTexture("../../../resources/textures/container2.png");
+	GLuint woodTexture      = loadTexture(FileSystem::getPath("resources/textures/wood.png").c_str());
+	GLuint containerTexture = loadTexture(FileSystem::getPath("resources/textures/container2.png").c_str());
 
 	// Set up floating point framebuffer to render scene to
 	GLuint hdrFBO;
@@ -386,7 +387,7 @@ void RenderCube()
 // This function loads a texture from file. Note: texture loading functions like these are usually 
 // managed by a 'Resource Manager' that manages all resources (like textures, models, audio). 
 // For learning purposes we'll just define it as a utility function.
-GLuint loadTexture(GLchar* path)
+GLuint loadTexture(GLchar const * path)
 {
 	// Generate texture ID and load texture data 
 	GLuint textureID;

--- a/src/5.advanced_lighting/8.deferred_shading/deferred_shading.cpp
+++ b/src/5.advanced_lighting/8.deferred_shading/deferred_shading.cpp
@@ -17,6 +17,7 @@
 
 // Other Libs
 #include <SOIL.h>
+#include <learnopengl/filesystem.h>
 
 // Properties
 const GLuint SCR_WIDTH = 800, SCR_HEIGHT = 600;
@@ -26,7 +27,7 @@ void key_callback(GLFWwindow* window, int key, int scancode, int action, int mod
 void scroll_callback(GLFWwindow* window, double xoffset, double yoffset);
 void mouse_callback(GLFWwindow* window, double xpos, double ypos);
 void Do_Movement();
-GLuint loadTexture(GLchar* path);
+GLuint loadTexture(GLchar const * path);
 void RenderCube();
 void RenderQuad();
 
@@ -84,7 +85,7 @@ int main()
     glUniform1i(glGetUniformLocation(shaderLightingPass.Program, "gAlbedoSpec"), 2);
 
 	// Models
-	Model cyborg("../../../resources/objects/nanosuit/nanosuit.obj");
+	Model cyborg(FileSystem::getPath("resources/objects/nanosuit/nanosuit.obj").c_str());
 	std::vector<glm::vec3> objectPositions;
     objectPositions.push_back(glm::vec3(-3.0, -3.0, -3.0));
     objectPositions.push_back(glm::vec3(0.0, -3.0, -3.0));
@@ -118,7 +119,7 @@ int main()
 	// 3 textures:
 	// 1. Positions (RGB)
 	// 2. Color (RGB) + Specular (A)
-	// 3. Normals (RGB) 
+	// 3. Normals (RGB)
 	GLuint gBuffer;
     glGenFramebuffers(1, &gBuffer);
     glBindFramebuffer(GL_FRAMEBUFFER, gBuffer);
@@ -144,7 +145,7 @@ int main()
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
     glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT2, GL_TEXTURE_2D, gAlbedoSpec, 0);
-    // - Tell OpenGL which color attachments we'll use (of this framebuffer) for rendering 
+    // - Tell OpenGL which color attachments we'll use (of this framebuffer) for rendering
     GLuint attachments[3] = { GL_COLOR_ATTACHMENT0, GL_COLOR_ATTACHMENT1, GL_COLOR_ATTACHMENT2 };
     glDrawBuffers(3, attachments);
 	// - Create and attach depth buffer (renderbuffer)
@@ -157,7 +158,7 @@ int main()
 	if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE)
 		std::cout << "Framebuffer not complete!" << std::endl;
 	glBindFramebuffer(GL_FRAMEBUFFER, 0);
-	
+
 	glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
 
 	// Game loop
@@ -219,7 +220,7 @@ int main()
             // Then calculate radius of light volume/sphere
             const GLfloat lightThreshold = 5.0; // 5 / 256
             const GLfloat maxBrightness = std::fmaxf(std::fmaxf(lightColors[i].r, lightColors[i].g), lightColors[i].b);
-            GLfloat radius = (-linear + std::sqrtf(linear * linear - 4 * quadratic * (constant - (256.0 / lightThreshold) * maxBrightness))) / (2 * quadratic);
+            GLfloat radius = (-linear + std::sqrt(linear * linear - 4 * quadratic * (constant - (256.0 / lightThreshold) * maxBrightness))) / (2 * quadratic);
             glUniform1f(glGetUniformLocation(shaderLightingPass.Program, ("lights[" + std::to_string(i) + "].Radius").c_str()), radius);
         }
         glUniform3fv(glGetUniformLocation(shaderLightingPass.Program, "viewPos"), 1, &camera.Position[0]);
@@ -298,7 +299,7 @@ void RenderCube()
             // Back face
             -0.5f, -0.5f, -0.5f, 0.0f, 0.0f, -1.0f, 0.0f, 0.0f, // Bottom-left
             0.5f, 0.5f, -0.5f, 0.0f, 0.0f, -1.0f, 1.0f, 1.0f, // top-right
-            0.5f, -0.5f, -0.5f, 0.0f, 0.0f, -1.0f, 1.0f, 0.0f, // bottom-right         
+            0.5f, -0.5f, -0.5f, 0.0f, 0.0f, -1.0f, 1.0f, 0.0f, // bottom-right
             0.5f, 0.5f, -0.5f, 0.0f, 0.0f, -1.0f, 1.0f, 1.0f,  // top-right
             -0.5f, -0.5f, -0.5f, 0.0f, 0.0f, -1.0f, 0.0f, 0.0f,  // bottom-left
             -0.5f, 0.5f, -0.5f, 0.0f, 0.0f, -1.0f, 0.0f, 1.0f,// top-left
@@ -319,10 +320,10 @@ void RenderCube()
             // Right face
             0.5f, 0.5f, 0.5f, 1.0f, 0.0f, 0.0f, 1.0f, 0.0f, // top-left
             0.5f, -0.5f, -0.5f, 1.0f, 0.0f, 0.0f, 0.0f, 1.0f, // bottom-right
-            0.5f, 0.5f, -0.5f, 1.0f, 0.0f, 0.0f, 1.0f, 1.0f, // top-right         
+            0.5f, 0.5f, -0.5f, 1.0f, 0.0f, 0.0f, 1.0f, 1.0f, // top-right
             0.5f, -0.5f, -0.5f, 1.0f, 0.0f, 0.0f, 0.0f, 1.0f,  // bottom-right
             0.5f, 0.5f, 0.5f, 1.0f, 0.0f, 0.0f, 1.0f, 0.0f,  // top-left
-            0.5f, -0.5f, 0.5f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, // bottom-left     
+            0.5f, -0.5f, 0.5f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, // bottom-left
             // Bottom face
             -0.5f, -0.5f, -0.5f, 0.0f, -1.0f, 0.0f, 0.0f, 1.0f, // top-right
             0.5f, -0.5f, -0.5f, 0.0f, -1.0f, 0.0f, 1.0f, 1.0f, // top-left
@@ -333,10 +334,10 @@ void RenderCube()
             // Top face
             -0.5f, 0.5f, -0.5f, 0.0f, 1.0f, 0.0f, 0.0f, 1.0f,// top-left
             0.5f, 0.5f, 0.5f, 0.0f, 1.0f, 0.0f, 1.0f, 0.0f, // bottom-right
-            0.5f, 0.5f, -0.5f, 0.0f, 1.0f, 0.0f, 1.0f, 1.0f, // top-right     
+            0.5f, 0.5f, -0.5f, 0.0f, 1.0f, 0.0f, 1.0f, 1.0f, // top-right
             0.5f, 0.5f, 0.5f, 0.0f, 1.0f, 0.0f, 1.0f, 0.0f, // bottom-right
             -0.5f, 0.5f, -0.5f, 0.0f, 1.0f, 0.0f, 0.0f, 1.0f,// top-left
-            -0.5f, 0.5f, 0.5f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f // bottom-left        
+            -0.5f, 0.5f, 0.5f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f // bottom-left
         };
         glGenVertexArrays(1, &cubeVAO);
         glGenBuffers(1, &cubeVBO);

--- a/src/5.advanced_lighting/9.ssao/ssao.cpp
+++ b/src/5.advanced_lighting/9.ssao/ssao.cpp
@@ -19,6 +19,7 @@
 #include <SOIL.h>
 
 #include <random> // necessary for generation of random floats (for sample kernel and noise texture)
+#include <learnopengl/filesystem.h>
 
 // Properties
 const GLuint SCR_WIDTH = 800, SCR_HEIGHT = 600;
@@ -96,7 +97,7 @@ int main()
     glUniform1i(glGetUniformLocation(shaderSSAO.Program, "texNoise"), 2);
 
     // Objects
-    Model nanosuit("../../../resources/objects/nanosuit/nanosuit.obj");
+    Model nanosuit(FileSystem::getPath("resources/objects/nanosuit/nanosuit.obj").c_str());
 
     // Lights
     glm::vec3 lightPos = glm::vec3(2.0, 4.0, -2.0);


### PR DESCRIPTION
Uses an environment variable to tell the program where to find resource files.
Shader sources are still search for in the current working directory.


From the readme:

> Note that using CodeBlocks or an IDE may have issues
> running the programs due to problems finding the shader
> and resource files.

This turned out to be a real problem with CLion, which places everything CMake related and all compiled binaries in its own hidden folders. To work around this I made it possible to set an environment variable (LOGL_ROOT_PATH for now). If that is set, then resource files are search there. If not, then the same ../../../ relative path as before is used.