### PR TITLE
Deferred Shading: Fixed bug with the normal texture component of the

### DIFF
--- a/src/5.advanced_lighting/8.deferred_shading/deferred_shading.cpp
+++ b/src/5.advanced_lighting/8.deferred_shading/deferred_shading.cpp
@@ -134,7 +134,7 @@ int main()
     // - Normal color buffer
     glGenTextures(1, &gNormal);
     glBindTexture(GL_TEXTURE_2D, gNormal);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, SCR_WIDTH, SCR_HEIGHT, 0, GL_RGB, GL_FLOAT, NULL);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB16F, SCR_WIDTH, SCR_HEIGHT, 0, GL_RGB, GL_FLOAT, NULL);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
     glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT1, GL_TEXTURE_2D, gNormal, 0);


### PR DESCRIPTION
gBuffer.

The texture was being set up as GL_RGB instead of GL_RGB16F which caused
negative components of normals to be set to 0.