### PR TITLE
Fix switching draw mode in SSAO deferred shader

### DIFF
--- a/src/5.advanced_lighting/9.ssao/ssao_lighting.frag
+++ b/src/5.advanced_lighting/9.ssao/ssao_lighting.frag
@@ -52,8 +52,8 @@ void main()
         FragColor = vec4(vec3(Depth / 50.0), 1.0);
     else if(draw_mode == 3)
         FragColor = vec4(FragPos, 1.0);
-     else if(draw_mode == 3)
+     else if(draw_mode == 4)
         FragColor = vec4(Normal, 1.0);
-    else if(draw_mode == 4)
+    else if(draw_mode == 5)
         FragColor = vec4(vec3(AmbientOcclusion), 1.0);
 }


### PR DESCRIPTION
It was not possible to view normals since its `draw_mode` was the same as the `draw_mode` for position.