### PR TITLE
Fixed the incorrectly bound shader that was preventing outlines from …

### DIFF
--- a/src/4.advanced_opengl/2.stencil_testing/stencil_testing.cpp
+++ b/src/4.advanced_opengl/2.stencil_testing/stencil_testing.cpp
@@ -196,8 +196,8 @@ int main()
         glm::mat4 model;
         glm::mat4 view = camera.GetViewMatrix();
         glm::mat4 projection = glm::perspective(camera.Zoom, (float)SCR_WIDTH / (float)SCR_HEIGHT, 0.1f, 100.0f);
-        shader.setMat4("view", view);
-        shader.setMat4("projection", projection);
+		shaderSingleColor.setMat4("view", view);
+		shaderSingleColor.setMat4("projection", projection);
 
         shader.use();
         shader.setMat4("view", view);
@@ -243,12 +243,12 @@ int main()
         model = glm::mat4();
         model = glm::translate(model, glm::vec3(-1.0f, 0.0f, -1.0f));
         model = glm::scale(model, glm::vec3(scale, scale, scale));
-        shader.setMat4("model", model);
+		shaderSingleColor.setMat4("model", model);
         glDrawArrays(GL_TRIANGLES, 0, 36);
         model = glm::mat4();
         model = glm::translate(model, glm::vec3(2.0f, 0.0f, 0.0f));
         model = glm::scale(model, glm::vec3(scale, scale, scale));
-        shader.setMat4("model", model);
+		shaderSingleColor.setMat4("model", model);
         glDrawArrays(GL_TRIANGLES, 0, 36);
         glBindVertexArray(0);
         glStencilMask(0xFF);


### PR DESCRIPTION
This should fix the outlines not being rendered. The outline shader uniforms are now correctly set.