### PR TITLE
Changed MSVC std::sqrtf call to simple std::sqrt on MinGW toolchain

### DIFF
--- a/src/5.advanced_lighting/8.2.deferred_shading_volumes/deferred_shading_volumes.cpp
+++ b/src/5.advanced_lighting/8.2.deferred_shading_volumes/deferred_shading_volumes.cpp
@@ -224,7 +224,7 @@ int main()
             shaderLightingPass.setFloat("lights[" + std::to_string(i) + "].Quadratic", quadratic);
             // then calculate radius of light volume/sphere
             const float maxBrightness = std::fmaxf(std::fmaxf(lightColors[i].r, lightColors[i].g), lightColors[i].b);
-            float radius = (-linear + std::sqrtf(linear * linear - 4 * quadratic * (constant - (256.0f / 5.0f) * maxBrightness))) / (2.0f * quadratic);
+            float radius = (-linear + std::sqrt(linear * linear - 4 * quadratic * (constant - (256.0f / 5.0f) * maxBrightness))) / (2.0f * quadratic);
             shaderLightingPass.setFloat("lights[" + std::to_string(i) + "].Radius", radius);
         }
         shaderLightingPass.setVec3("viewPos", camera.Position);


### PR DESCRIPTION
Changed MSVC std::sqrtf call to simple std::sqrt - causes compile failure on mingw toolchain, as no such function is present.