### PR TITLE
Fix Bloom in rare cases

### DIFF
--- a/src/5.advanced_lighting/7.bloom/7.bloom.fs
+++ b/src/5.advanced_lighting/7.bloom/7.bloom.fs
@@ -43,7 +43,7 @@ void main()
     float brightness = dot(result, vec3(0.2126, 0.7152, 0.0722));
     if(brightness > 1.0)
         BrightColor = vec4(result, 1.0);
-    // else
-        // BloomColor = vec4(0.0, 0.0, 0.0, 1.0);
+    else
+        BloomColor = vec4(0.0, 0.0, 0.0, 1.0);
     FragColor = vec4(result, 1.0);
 }

--- a/src/5.advanced_lighting/7.bloom/7.bloom.fs
+++ b/src/5.advanced_lighting/7.bloom/7.bloom.fs
@@ -44,6 +44,6 @@ void main()
     if(brightness > 1.0)
         BrightColor = vec4(result, 1.0);
     else
-        BloomColor = vec4(0.0, 0.0, 0.0, 1.0);
+        BrightColor = vec4(0.0, 0.0, 0.0, 1.0);
     FragColor = vec4(result, 1.0);
 }


### PR DESCRIPTION
BloomColor was not initialized with a value and therefore could incorrectly bloom non-bright pixels.

Maybe... since the issue randomly started to happen on my system (i5-4570, GTX 760) without any hardware or software changes I know of. Even older versions of my program then suddenly had this problem and this was the only working fix which was mentioned in the comments section on the tutorial: https://learnopengl.com/#!Advanced-Lighting/Bloom#comment-2693931521