### PR TITLE
Fix rare graphical error showing a black box

### DIFF
--- a/src/6.pbr/1.1.lighting/1.1.pbr.fs
+++ b/src/6.pbr/1.1.lighting/1.1.pbr.fs
@@ -82,7 +82,7 @@ void main()
         // Cook-Torrance BRDF
         float NDF = DistributionGGX(N, H, roughness);   
         float G   = GeometrySmith(N, V, L, roughness);      
-        vec3 F    = fresnelSchlick(max(dot(H, V), 0.0), F0);
+        vec3 F    = fresnelSchlick(clamp(dot(H, V), 0.0, 1.0), F0);
            
         vec3 nominator    = NDF * G * F; 
         float denominator = 4 * max(dot(N, V), 0.0) * max(dot(N, L), 0.0) + 0.001; // 0.001 to prevent divide by zero.


### PR DESCRIPTION
This may happen at certain hard to replicate viewing angles.

Theoretically clamp 0,1 should also be faster since SAT (saturate) is a free operation on output however since saturate only exists on HLSL we are at the mercy of the GLSL compiler to replace clamp 0,1 with SAT. Source: http://www.humus.name/Articles/Persson_LowLevelThinking.pdf#page=22