### PR TITLE
Fix another graphical error showing a black box

### DIFF
--- a/src/6.pbr/1.1.lighting/1.1.pbr.fs
+++ b/src/6.pbr/1.1.lighting/1.1.pbr.fs
@@ -29,7 +29,7 @@ float DistributionGGX(vec3 N, vec3 H, float roughness)
     float denom = (NdotH2 * (a2 - 1.0) + 1.0);
     denom = PI * denom * denom;
 
-    return nom / denom;
+    return nom / max(denom, 0.001); // prevent divide by zero for roughness=0.0 and NdotH=1.0
 }
 // ----------------------------------------------------------------------------
 float GeometrySchlickGGX(float NdotV, float roughness)
@@ -85,8 +85,8 @@ void main()
         vec3 F    = fresnelSchlick(max(dot(H, V), 0.0), F0);
            
         vec3 nominator    = NDF * G * F; 
-        float denominator = 4 * max(dot(N, V), 0.0) * max(dot(N, L), 0.0) + 0.001; // 0.001 to prevent divide by zero.
-        vec3 specular = nominator / denominator;
+        float denominator = 4 * max(dot(N, V), 0.0) * max(dot(N, L), 0.0);
+        vec3 specular = nominator / max(denominator, 0.001); // prevent divide by zero for NdotV=0.0 or NdotL=0.0
         
         // kS is equal to Fresnel
         vec3 kS = F;


### PR DESCRIPTION
Is needed in addition to #92 to fix all graphical errors. Happens due to divide by 0 when `roughness = 0.0` and `NdotH = 1.0`.

Also use max to clamp similar fix for specular calculation instead of addition to fix the formula in normal cases