### PR TITLE
decoupled assimp from mesh.h

### DIFF
--- a/includes/learnopengl/mesh.h
+++ b/includes/learnopengl/mesh.h
@@ -3,8 +3,6 @@
 
 #include <glad/glad.h> // holds all OpenGL type declarations
 
-#include <assimp/Importer.hpp>
-
 #include <glm/glm.hpp>
 #include <glm/gtc/matrix_transform.hpp>
 
@@ -33,7 +31,7 @@ struct Vertex {
 struct Texture {
     unsigned int id;
     string type;
-    aiString path;
+    string path;
 };
 
 class Mesh {

--- a/includes/learnopengl/model.h
+++ b/includes/learnopengl/model.h
@@ -179,7 +179,7 @@ private:
             bool skip = false;
             for(unsigned int j = 0; j < textures_loaded.size(); j++)
             {
-                if(std::strcmp(textures_loaded[j].path.C_Str(), str.C_Str()) == 0)
+                if(std::strcmp(textures_loaded[j].path.data(), str.C_Str()) == 0)
                 {
                     textures.push_back(textures_loaded[j]);
                     skip = true; // a texture with the same filepath has already been loaded, continue to next one. (optimization)
@@ -191,7 +191,7 @@ private:
                 Texture texture;
                 texture.id = TextureFromFile(str.C_Str(), this->directory);
                 texture.type = typeName;
-                texture.path = str;
+                texture.path = str.C_Str();
                 textures.push_back(texture);
                 textures_loaded.push_back(texture);  // store it as texture loaded for entire model, to ensure we won't unnecesery load duplicate textures.
             }


### PR DESCRIPTION
Hi, I removed the assimp dependency from the mesh header. I think that it is much easier to understand the purpose of the mesh class vs. the model class if assimp is only used in the model, which loads meshes.