### PR TITLE
Another take on PBR tutorials missing rows and columns

### DIFF
--- a/src/6.pbr/1.1.lighting/lighting.cpp
+++ b/src/6.pbr/1.1.lighting/lighting.cpp
@@ -132,10 +132,10 @@ int main()
 
         // render rows*column number of spheres with varying metallic/roughness values scaled by rows and columns respectively
         glm::mat4 model;
-        for (unsigned int row = 0; row < nrRows; ++row) 
+        for (int row = 0; row < nrRows; ++row) 
         {
             shader.setFloat("metallic", (float)row / (float)nrRows);
-            for (unsigned int col = 0; col < nrColumns; ++col) 
+            for (int col = 0; col < nrColumns; ++col) 
             {
                 // we clamp the roughness to 0.025 - 1.0 as perfectly smooth surfaces (roughness of 0.0) tend to look a bit off
                 // on direct lighting.
@@ -143,8 +143,8 @@ int main()
                 
                 model = glm::mat4();
                 model = glm::translate(model, glm::vec3(
-                    (col - (nrColumns / 2.)) * spacing, 
-                    (row - (nrRows / 2.)) * spacing, 
+                    (col - (nrColumns / 2)) * spacing, 
+                    (row - (nrRows / 2)) * spacing, 
                     0.0f
                 ));
                 shader.setMat4("model", model);

--- a/src/6.pbr/1.2.lighting_textured/lighting_textured.cpp
+++ b/src/6.pbr/1.2.lighting_textured/lighting_textured.cpp
@@ -148,9 +148,9 @@ int main()
 
         // render rows*column number of spheres with material properties defined by textures (they all have the same material properties)
         glm::mat4 model;
-        for (unsigned int row = 0; row < nrRows; ++row)
+        for (int row = 0; row < nrRows; ++row)
         {
-            for (unsigned int col = 0; col < nrColumns; ++col)
+            for (int col = 0; col < nrColumns; ++col)
             {
                 model = glm::mat4();
                 model = glm::translate(model, glm::vec3(


### PR DESCRIPTION
Well, after reiterating a bit more attentively this code snippet I'm here to atone my sins.
Issue is not in integer division, as it's still does it's work. Culprit is in implicit type conversion. 
To be more precise signed -> unsigned int conversion that takes place in position calculation and creates negative overflow.

Sorry for the mess, Joey)