### PR TITLE
LN134: The second parameter internalFormat GL_RGB will not work on Op…

### DIFF
--- a/src/1.getting_started/4.2.textures_combined/textures_combined.cpp
+++ b/src/1.getting_started/4.2.textures_combined/textures_combined.cpp
@@ -131,7 +131,7 @@ int main()
     if (data)
     {
         // note that the awesomeface.png has transparency and thus an alpha channel, so make sure to tell OpenGL the data type is of GL_RGBA
-        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, data);
+        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, data);
         glGenerateMipmap(GL_TEXTURE_2D);
     }
     else


### PR DESCRIPTION
1.getting_started/4.2.textures_combined/textures_combined.cpp
LN134: The second parameter internalFormat GL_RGB will not work on OpenGL es. GL_RGB should be GL_RGBA.