### PR TITLE
Zero out memory from color variable

### DIFF
--- a/src/7.in_practice/3.2d_game/0.full_source/shaders/post_processing.frag
+++ b/src/7.in_practice/3.2d_game/0.full_source/shaders/post_processing.frag
@@ -13,6 +13,9 @@ uniform bool shake;
 
 void main()
 {
+    // zero out memory since an out variable is initialized with undefined values by default 
+    color = vec4(0.0f);
+
     vec3 sample[9];
     // sample from texture offsets if using convolution matrix
     if(chaos || shake)


### PR DESCRIPTION
According to [here](https://www.khronos.org/opengl/wiki/Type_Qualifier_(GLSL)#Fragment_shader_outputs) memory of a fragment shader variable is initialized with undefined values. Therefore it should be zeroed out.