### PR TITLE
Fix 'use' and 'ID' in two places each, delete second main()

### DIFF
--- a/src/7.in_practice/2.text_rendering/text_rendering.cpp
+++ b/src/7.in_practice/2.text_rendering/text_rendering.cpp
@@ -76,8 +76,8 @@ int main()
     // ----------------------------
     Shader shader("text.vs", "text.fs");
     glm::mat4 projection = glm::ortho(0.0f, static_cast<float>(SCR_WIDTH), 0.0f, static_cast<float>(SCR_HEIGHT));
-    shader.Use();
-    glUniformMatrix4fv(glGetUniformLocation(shader.Program, "projection"), 1, GL_FALSE, glm::value_ptr(projection));
+    shader.use();
+    glUniformMatrix4fv(glGetUniformLocation(shader.ID, "projection"), 1, GL_FALSE, glm::value_ptr(projection));
 
     // FreeType
     // --------
@@ -179,34 +179,6 @@ int main()
     return 0;
 }
 
-// The MAIN function, from here we start our application and run the Game loop
-int main()
-{
-    // Init GLFW
-    glfwInit();
-    glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
-    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
-    glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
-    glfwWindowHint(GLFW_RESIZABLE, GL_FALSE);
-
-    GLFWwindow* window = glfwCreateWindow(WIDTH, HEIGHT, "LearnOpenGL", nullptr, nullptr); // Windowed
-    glfwMakeContextCurrent(window);
-
-    // Initialize GLEW to setup the OpenGL Function pointers
-    glewExperimental = GL_TRUE;
-    glewInit();
-
-    // Define the viewport dimensions
-    glViewport(0, 0, WIDTH, HEIGHT);
-
-    // Set OpenGL options
-    glEnable(GL_CULL_FACE);
-    glEnable(GL_BLEND);
-    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-
-    
-}
-
 // process all input: query GLFW whether relevant keys are pressed/released this frame and react accordingly
 // ---------------------------------------------------------------------------------------------------------
 void processInput(GLFWwindow *window)
@@ -230,8 +202,8 @@ void framebuffer_size_callback(GLFWwindow* window, int width, int height)
 void RenderText(Shader &shader, std::string text, float x, float y, float scale, glm::vec3 color)
 {
     // activate corresponding render state	
-    shader.Use();
-    glUniform3f(glGetUniformLocation(shader.Program, "textColor"), color.x, color.y, color.z);
+    shader.use();
+    glUniform3f(glGetUniformLocation(shader.ID, "textColor"), color.x, color.y, color.z);
     glActiveTexture(GL_TEXTURE0);
     glBindVertexArray(VAO);
 


### PR DESCRIPTION
Would it make sense to add a 'readme.md' to the text rendering source folder, telling what steps would be needed to download and install Freetype2?

Such as add Freetype2 to the includes folder and to the lib folder.  Also, change the font load path at line 91 in text_rendering.cpp from "fonts/arial.ttf" to "C:/Windows/Fonts/arial.ttf".

