### PR TITLE
Make font loading more reliably.

### DIFF
--- a/src/7.in_practice/2.text_rendering/text_rendering.cpp
+++ b/src/7.in_practice/2.text_rendering/text_rendering.cpp
@@ -91,16 +91,16 @@ int main()
     }
 
 	// find path to font
-	const char *font_name = FileSystem::getPath("resources/fonts/Antonio-Bold.ttf").c_str();
-    if(!font_name)
+    std::string font_name = FileSystem::getPath("resources/fonts/Antonio-Bold.ttf");
+    if (font_name.empty())
     {
-        std::cout << "ERROR::FREETYPE: Failed to load font_name: " << font_name << std::endl;
+        std::cout << "ERROR::FREETYPE: Failed to load font_name" << std::endl;
         return -1;
     }
 	
 	// load font as face
     FT_Face face;
-    if (FT_New_Face(ft, font_name, 0, &face)) {
+    if (FT_New_Face(ft, font_name.c_str(), 0, &face)) {
         std::cout << "ERROR::FREETYPE: Failed to load font" << std::endl;
         return -1;
     }


### PR DESCRIPTION
`FileSystem::getPath()` returns a temporary object so we save the result in an `std::string` object (rather than a pointer).

This makes it work on Ubuntu 18.04 where it was failing previously.