### PR TITLE
Fix hardcoded lights number in 1.2 PBR shader

### DIFF
--- a/src/6.pbr/1.2.lighting_textured/1.2.pbr.fs
+++ b/src/6.pbr/1.2.lighting_textured/1.2.pbr.fs
@@ -14,6 +14,7 @@ uniform sampler2D aoMap;
 // lights
 uniform vec3 lightPositions[4];
 uniform vec3 lightColors[4];
+uniform int lightsNumber;
 
 uniform vec3 camPos;
 
@@ -97,7 +98,7 @@ void main()
 
     // reflectance equation
     vec3 Lo = vec3(0.0);
-    for(int i = 0; i < 4; ++i) 
+    for(int i = 0; i < lightsNumber; ++i)
     {
         // calculate per-light radiance
         vec3 L = normalize(lightPositions[i] - WorldPos);

--- a/src/6.pbr/1.2.lighting_textured/lighting_textured.cpp
+++ b/src/6.pbr/1.2.lighting_textured/lighting_textured.cpp
@@ -114,6 +114,9 @@ int main()
     shader.use();
     shader.setMat4("projection", projection);
 
+	const int lightsNumber = sizeof(lightPositions) / sizeof(lightPositions[0]);
+	shader.setInt("lightsNumber", lightsNumber);
+
     // render loop
     // -----------
     while (!glfwWindowShouldClose(window))
@@ -167,9 +170,9 @@ int main()
         }
 
         // render light source (simply re-render sphere at light positions)
-        // this looks a bit off as we use the same shader, but it'll make their positions obvious and 
+        // this looks a bit off as we use the same shader, but it'll make their positions obvious and
         // keeps the codeprint small.
-        for (unsigned int i = 0; i < sizeof(lightPositions) / sizeof(lightPositions[0]); ++i)
+        for (unsigned int i = 0; i < lightsNumber; ++i)
         {
             glm::vec3 newPos = lightPositions[i] + glm::vec3(sin(glfwGetTime() * 5.0) * 5.0, 0.0, 0.0);
             newPos = lightPositions[i];
@@ -216,7 +219,7 @@ void processInput(GLFWwindow *window)
 // ---------------------------------------------------------------------------------------------
 void framebuffer_size_callback(GLFWwindow* window, int width, int height)
 {
-    // make sure the viewport matches the new window dimensions; note that width and 
+    // make sure the viewport matches the new window dimensions; note that width and
     // height will be significantly larger than specified on retina displays.
     glViewport(0, 0, width, height);
 }


### PR DESCRIPTION
The number of lights in the 1.2 PBR example was still set to 4 (from the previous example) but in this example there is only one light.

I added an uniform variable to make the light number more programmable and avoid this kind of hardcoded error.