### PR TITLE
Fix model loading example to handle diverse object files

### DIFF
--- a/src/3.model_loading/1.model_loading/1.model_loading.fs
+++ b/src/3.model_loading/1.model_loading/1.model_loading.fs
@@ -2,10 +2,37 @@
 out vec4 FragColor;
 
 in vec2 TexCoords;
+in vec3 Normal;  
+in vec3 FragPos;  
 
 uniform sampler2D texture_diffuse1;
+uniform vec3 lightPos; 
+uniform vec3 viewPos; 
+uniform vec3 lightColor;
+uniform vec3 objectColor;
+uniform bool hasTextures;
 
 void main()
 {    
-    FragColor = texture(texture_diffuse1, TexCoords);
+    vec3 fColor = hasTextures ? texture(texture_diffuse1, TexCoords).rgb : objectColor;
+
+    // ambient
+    float ambientStrength = 0.1;
+    vec3 ambient = ambientStrength * lightColor;
+  	
+    // diffuse 
+    vec3 norm = normalize(Normal);
+    vec3 lightDir = normalize(lightPos - FragPos);
+    float diff = max(dot(norm, lightDir), 0.0);
+    vec3 diffuse = diff * lightColor;
+    
+    // specular
+    float specularStrength = 0.5;
+    vec3 viewDir = normalize(viewPos - FragPos);
+    vec3 reflectDir = reflect(-lightDir, norm);  
+    float spec = pow(max(dot(viewDir, reflectDir), 0.0), 32);
+    vec3 specular = specularStrength * spec * lightColor;  
+        
+    vec3 result = (ambient + diffuse + specular) * fColor;
+    FragColor = vec4(result, 1.0);
 }

--- a/src/3.model_loading/1.model_loading/1.model_loading.vs
+++ b/src/3.model_loading/1.model_loading/1.model_loading.vs
@@ -4,6 +4,8 @@ layout (location = 1) in vec3 aNormal;
 layout (location = 2) in vec2 aTexCoords;
 
 out vec2 TexCoords;
+out vec3 FragPos;
+out vec3 Normal;
 
 uniform mat4 model;
 uniform mat4 view;
@@ -12,5 +14,8 @@ uniform mat4 projection;
 void main()
 {
     TexCoords = aTexCoords;    
-    gl_Position = projection * view * model * vec4(aPos, 1.0);
+    FragPos = vec3(model * vec4(aPos, 1.0));
+    Normal = mat3(transpose(inverse(model))) * aNormal;  
+
+    gl_Position = projection * view * vec4(FragPos, 1.0);
 }

--- a/src/3.model_loading/1.model_loading/model_loading.cpp
+++ b/src/3.model_loading/1.model_loading/model_loading.cpp
@@ -31,6 +31,9 @@ bool firstMouse = true;
 float deltaTime = 0.0f;
 float lastFrame = 0.0f;
 
+// lighting
+glm::vec3 lightPos(1.2f, 1.0f, 2.0f);
+
 int main()
 {
     // glfw: initialize and configure
@@ -83,6 +86,7 @@ int main()
     // load models
     // -----------
     Model ourModel(FileSystem::getPath("resources/objects/backpack/backpack.obj"));
+    bool hasTextures = (ourModel.textures_loaded.size() == 0) ? 0 : 1;
 
     
     // draw in wireframe
@@ -109,6 +113,11 @@ int main()
 
         // don't forget to enable shader before setting uniforms
         ourShader.use();
+        ourShader.setVec3("objectColor", 1.0f, 0.5f, 0.31f);
+        ourShader.setVec3("lightColor", 1.0f, 1.0f, 1.0f);
+        ourShader.setVec3("lightPos", lightPos);
+        ourShader.setVec3("viewPos", camera.Position);
+        ourShader.setInt("hasTextures", hasTextures);
 
         // view/projection transformations
         glm::mat4 projection = glm::perspective(glm::radians(camera.Zoom), (float)SCR_WIDTH / (float)SCR_HEIGHT, 0.1f, 100.0f);


### PR DESCRIPTION
Hi Joey,

I fixed the model load example to consider diverse object files, such as the ones without texture files. This fix does not hurt your example. It considers whether the object file has a texture file or not, and decide which one to render, the color that the user set or the texture. However, I changed the lighting to the one in the [basic lighting in Chapter 2](https://github.com/JoeyDeVries/LearnOpenGL/tree/master/src/2.lighting/2.2.basic_lighting_specular)  with some extra variables to successfully show the rendering result of one-colored objects.

Sorry for the multiple PR. I was hesitating if I should include it in the last PR or not and I decided to give it a try! Take a look and feel free to merge it or not :)
