### PR TITLE
Renamed sample -> samplePos because sample is a keyword in future glsl versions

### DIFF
--- a/src/5.advanced_lighting/9.ssao/9.ssao.fs
+++ b/src/5.advanced_lighting/9.ssao/9.ssao.fs
@@ -34,11 +34,11 @@ void main()
     for(int i = 0; i < kernelSize; ++i)
     {
         // get sample position
-        vec3 sample = TBN * samples[i]; // from tangent to view-space
-        sample = fragPos + sample * radius; 
+        vec3 samplePos = TBN * samples[i]; // from tangent to view-space
+        samplePos = fragPos + samplePos * radius; 
         
         // project sample position (to sample texture) (to get position on screen/texture)
-        vec4 offset = vec4(sample, 1.0);
+        vec4 offset = vec4(samplePos, 1.0);
         offset = projection * offset; // from view to clip-space
         offset.xyz /= offset.w; // perspective divide
         offset.xyz = offset.xyz * 0.5 + 0.5; // transform to range 0.0 - 1.0
@@ -48,7 +48,7 @@ void main()
         
         // range check & accumulate
         float rangeCheck = smoothstep(0.0, 1.0, radius / abs(fragPos.z - sampleDepth));
-        occlusion += (sampleDepth >= sample.z + bias ? 1.0 : 0.0) * rangeCheck;           
+        occlusion += (sampleDepth >= samplePos.z + bias ? 1.0 : 0.0) * rangeCheck;           
     }
     occlusion = 1.0 - (occlusion / kernelSize);
     


### PR DESCRIPTION
This isn't a big deal or perhaps something not worth while at all

but some version in glsl ```sample``` got turned into a keyword (for me it didn't work on 4.1 core) causing a shader compilation error in the ssao example.

[This spec shows it on page 25](https://www.khronos.org/registry/OpenGL/specs/gl/GLSLangSpec.4.50.pdf).

My one argument for it is that up until this point everything has worked great (love the tutorial so much btw) on 4.1 core but I totally understand not wanting to worry about future versions.