### PR TITLE
Make 'Shader::use()' const as well

### DIFF
--- a/includes/learnopengl/shader_s.h
+++ b/includes/learnopengl/shader_s.h
@@ -70,7 +70,7 @@ public:
     }
     // activate the shader
     // ------------------------------------------------------------------------
-    void use() 
+    void use() const
     { 
         glUseProgram(ID); 
     }


### PR DESCRIPTION
I believe that function can be const as well. Compiled all the projects and there was no error after the change.
Was there a specific reason to not be const?