### PR TITLE
Clear GL_COLOR_BUFFER_BIT before entering render loop

### DIFF
--- a/src/1.getting_started/1.1.hello_window/hello_window.cpp
+++ b/src/1.getting_started/1.1.hello_window/hello_window.cpp
@@ -41,7 +41,9 @@ int main()
     {
         std::cout << "Failed to initialize GLAD" << std::endl;
         return -1;
-    }    
+    }
+    
+    glClear(GL_COLOR_BUFFER_BIT);
 
     // render loop
     // -----------


### PR DESCRIPTION
Ensure that GL_COLOR_BUFFER_BIT is cleared before entering the render loop. (At least on macOS 11.2) Without this change, the rendered window keeps flashing red and black _very_ fast.