### PR TITLE
Added glClear() to avoid *really* scary screen flickering

### DIFF
--- a/src/1.getting_started/1.1.hello_window/hello_window.cpp
+++ b/src/1.getting_started/1.1.hello_window/hello_window.cpp
@@ -53,7 +53,8 @@ int main()
 
         // glfw: swap buffers and poll IO events (keys pressed/released, mouse moved etc.)
         // -------------------------------------------------------------------------------
-        glfwSwapBuffers(window);
+        glClear(GL_COLOR_BUFFER_BIT);
+		glfwSwapBuffers(window);
         glfwPollEvents();
     }
 


### PR DESCRIPTION
I'm learning OpenGL, and when i followed the first tutorial my screen was just flickering without reasons instead of being completely black. So I discovered that before swapping the buffers I needed to clear the buffer first. Thanks to this answer: https://stackoverflow.com/a/27679342
