### PR TITLE
Fix bug: glDisable(GL_DEPTH) -> glDisable(GL_DEPTH_TEST)

### DIFF
--- a/src/8.guest/2020/oit/weighted_blended.cpp
+++ b/src/8.guest/2020/oit/weighted_blended.cpp
@@ -273,7 +273,7 @@ int main(int argc, char* argv[])
 		// -----
 
 		// set render states
-		glDisable(GL_DEPTH);
+		glDisable(GL_DEPTH_TEST);
 		glDepthMask(GL_TRUE); // enable depth writes so glClear won't ignore clearing the depth buffer
 		glDisable(GL_BLEND);
 


### PR DESCRIPTION
I found this bug while implementing the OIT tutorial. ``glDisable(GL_DEPTH)`` gives out an OpenGL error on my AMD 5700 XT (Maybe this error slipped through because of GPU driver differences?)