### PR TITLE
Fix typo: nominator to numerator.

### DIFF
--- a/src/6.pbr/1.1.lighting/1.1.pbr.fs
+++ b/src/6.pbr/1.1.lighting/1.1.pbr.fs
@@ -84,9 +84,9 @@ void main()
         float G   = GeometrySmith(N, V, L, roughness);      
         vec3 F    = fresnelSchlick(clamp(dot(H, V), 0.0, 1.0), F0);
            
-        vec3 nominator    = NDF * G * F; 
+        vec3 numerator    = NDF * G * F; 
         float denominator = 4 * max(dot(N, V), 0.0) * max(dot(N, L), 0.0);
-        vec3 specular = nominator / max(denominator, 0.001); // prevent divide by zero for NdotV=0.0 or NdotL=0.0
+        vec3 specular = numerator / max(denominator, 0.001); // prevent divide by zero for NdotV=0.0 or NdotL=0.0
         
         // kS is equal to Fresnel
         vec3 kS = F;

--- a/src/6.pbr/1.2.lighting_textured/1.2.pbr.fs
+++ b/src/6.pbr/1.2.lighting_textured/1.2.pbr.fs
@@ -111,9 +111,9 @@ void main()
         float G   = GeometrySmith(N, V, L, roughness);      
         vec3 F    = fresnelSchlick(max(dot(H, V), 0.0), F0);
            
-        vec3 nominator    = NDF * G * F; 
+        vec3 numerator    = NDF * G * F; 
         float denominator = 4 * max(dot(N, V), 0.0) * max(dot(N, L), 0.0) + 0.001; // 0.001 to prevent divide by zero.
-        vec3 specular = nominator / denominator;
+        vec3 specular = numerator / denominator;
         
         // kS is equal to Fresnel
         vec3 kS = F;

--- a/src/6.pbr/2.1.1.ibl_irradiance_conversion/2.1.1.pbr.fs
+++ b/src/6.pbr/2.1.1.ibl_irradiance_conversion/2.1.1.pbr.fs
@@ -85,9 +85,9 @@ void main()
         float G   = GeometrySmith(N, V, L, roughness);      
         vec3 F    = fresnelSchlick(max(dot(H, V), 0.0), F0);
            
-        vec3 nominator    = NDF * G * F; 
+        vec3 numerator    = NDF * G * F; 
         float denominator = 4 * max(dot(N, V), 0.0) * max(dot(N, L), 0.0) + 0.001; // 0.001 to prevent divide by zero.
-        vec3 specular = nominator / denominator;
+        vec3 specular = numerator / denominator;
         
         // kS is equal to Fresnel
         vec3 kS = F;

--- a/src/6.pbr/2.1.2.ibl_irradiance/2.1.2.pbr.fs
+++ b/src/6.pbr/2.1.2.ibl_irradiance/2.1.2.pbr.fs
@@ -88,9 +88,9 @@ void main()
         float G   = GeometrySmith(N, V, L, roughness);    
         vec3 F    = fresnelSchlick(max(dot(H, V), 0.0), F0);        
         
-        vec3 nominator    = NDF * G * F;
+        vec3 numerator    = NDF * G * F;
         float denominator = 4 * max(dot(N, V), 0.0) * max(dot(N, L), 0.0) + 0.001; // 0.001 to prevent divide by zero.
-        vec3 specular = nominator / denominator;
+        vec3 specular = numerator / denominator;
         
          // kS is equal to Fresnel
         vec3 kS = F;

--- a/src/6.pbr/2.2.1.ibl_specular/2.2.1.pbr.fs
+++ b/src/6.pbr/2.2.1.ibl_specular/2.2.1.pbr.fs
@@ -95,9 +95,9 @@ void main()
         float G   = GeometrySmith(N, V, L, roughness);    
         vec3 F    = fresnelSchlick(max(dot(H, V), 0.0), F0);        
         
-        vec3 nominator    = NDF * G * F;
+        vec3 numerator    = NDF * G * F;
         float denominator = 4 * max(dot(N, V), 0.0) * max(dot(N, L), 0.0) + 0.001; // 0.001 to prevent divide by zero.
-        vec3 specular = nominator / denominator;
+        vec3 specular = numerator / denominator;
         
          // kS is equal to Fresnel
         vec3 kS = F;

--- a/src/6.pbr/2.2.2.ibl_specular_textured/2.2.2.pbr.fs
+++ b/src/6.pbr/2.2.2.ibl_specular_textured/2.2.2.pbr.fs
@@ -124,9 +124,9 @@ void main()
         float G   = GeometrySmith(N, V, L, roughness);    
         vec3 F    = fresnelSchlick(max(dot(H, V), 0.0), F0);        
         
-        vec3 nominator    = NDF * G * F;
+        vec3 numerator    = NDF * G * F;
         float denominator = 4 * max(dot(N, V), 0.0) * max(dot(N, L), 0.0) + 0.001; // 0.001 to prevent divide by zero.
-        vec3 specular = nominator / denominator;
+        vec3 specular = numerator / denominator;
         
          // kS is equal to Fresnel
         vec3 kS = F;


### PR DESCRIPTION
@JoeyDeVries Thanks a lot for your awesome tutorial!

Seems found a typo, should use `numerator` instead of `nominator`?