### PR TITLE
Fix FPS camera movement bug

### DIFF
--- a/src/1.getting_started/7.5.camera_exercise1/camera_exercise1.cpp
+++ b/src/1.getting_started/7.5.camera_exercise1/camera_exercise1.cpp
@@ -5,16 +5,18 @@
 // processes input received from any keyboard-like input system. Accepts input parameter in the form of camera defined ENUM (to abstract it from windowing systems)
 void ProcessKeyboard(Camera_Movement direction, float deltaTime)
 {
+    // Make sure the user stays at the ground level by setting the y axis to 0
+    // The x and z axis should not include pitch as you will only move horizontally
+    glm::vec3 forward = glm::vec3(cos(glm::radians(Yaw)), 0.0f, sin(glm::radians(Yaw)));
+
     float velocity = MovementSpeed * deltaTime;
     if (direction == FORWARD)
-        Position += Front * velocity;
+        Position += forward * velocity;     // Add the forward vector to position
     if (direction == BACKWARD)
-        Position -= Front * velocity;
+        Position -= forward * velocity;     // Subtract the forward vector from position
     if (direction == LEFT)
         Position -= Right * velocity;
     if (direction == RIGHT)
         Position += Right * velocity;
-    // make sure the user stays at the ground level
-    Position.y = 0.0f; // <-- this one-liner keeps the user at the ground level (xz plane)
 }
 [...]


### PR DESCRIPTION
In chapter 1, the first exercise from section 10.10 asks to convert the camera to be a true fps camera, with no vertical movement. The original code simply sets the y axis of the position to 0 to block vertical movement, but there is a bug where if the player is looking directly up or down, the player will slow down to a halt because it is the vertical vector from the pitch is added to the position. 

I fixed this by creating a new vector that only adds the yaw (horizontal) axis while leaving the y-axis to 0. Less computation as well.