### PR TITLE
Fix a minor bug in rear view mirror

### DIFF
--- a/src/4.advanced_opengl/5.2.framebuffers_exercise1/framebuffers_exercise1.cpp
+++ b/src/4.advanced_opengl/5.2.framebuffers_exercise1/framebuffers_exercise1.cpp
@@ -250,11 +250,9 @@ int main()
         shader.use();
         glm::mat4 model = glm::mat4(1.0f);
         camera.Yaw   += 180.0f; // rotate the camera's yaw 180 degrees around
-        camera.Pitch += 180.0f; // rotate the camera's pitch 180 degrees around
         camera.ProcessMouseMovement(0, 0, false); // call this to make sure it updates its camera vectors, note that we disable pitch constrains for this specific case (otherwise we can't reverse camera's pitch values)
         glm::mat4 view = camera.GetViewMatrix();
         camera.Yaw   -= 180.0f; // reset it back to its original orientation
-        camera.Pitch -= 180.0f;
         camera.ProcessMouseMovement(0, 0, true); 
         glm::mat4 projection = glm::perspective(glm::radians(camera.Zoom), (float)SCR_WIDTH / (float)SCR_HEIGHT, 0.1f, 100.0f);
         shader.setMat4("view", view);


### PR DESCRIPTION
Rotating both the Yaw and Pitch would cause the mirror to display whatever was in front but with Pitch * -1, this fixes this behaviour. Tested.

Before:
![obraz](https://user-images.githubusercontent.com/41419822/130130122-3e517331-c58b-405b-8af2-973e2b0dff32.png)
After:
![obraz](https://user-images.githubusercontent.com/41419822/130130036-af084e30-bfb2-476a-aa98-0a548df89ad9.png)