### PR TITLE
Fix glBufferDelete() argument mistake in cubemaps_skybox.cpp

### DIFF
--- a/src/4.advanced_opengl/6.1.cubemaps_skybox/cubemaps_skybox.cpp
+++ b/src/4.advanced_opengl/6.1.cubemaps_skybox/cubemaps_skybox.cpp
@@ -275,7 +275,7 @@ int main()
     glDeleteVertexArrays(1, &cubeVAO);
     glDeleteVertexArrays(1, &skyboxVAO);
     glDeleteBuffers(1, &cubeVBO);
-    glDeleteBuffers(1, &skyboxVAO);
+    glDeleteBuffers(1, &skyboxVBO);
 
     glfwTerminate();
     return 0;


### PR DESCRIPTION
In cubemaps_skybox.cpp, the second argument to glBufferDelete() should be &SkyboxVBO instead of &SkyboxVAO.