### PR TITLE
Guest article builds + windows build script.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # ignores following folders
 bin/
 build/
+out/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,7 +169,16 @@ set(7.in_practice
     #3.2d_game
 )
 
-
+set(GUEST_ARTICLES
+	8.guest/2020/oit
+	8.guest/2020/skeletal_animation
+	8.guest/2021/1.scene/1.scene_graph
+	8.guest/2021/1.scene/2.frustum_culling
+	8.guest/2021/2.csm
+	8.guest/2021/3.tessellation/terrain_gpu_dist
+	8.guest/2021/3.tessellation/terrain_cpu_src
+	8.guest/2021/4.dsa
+)
 
 configure_file(configuration/root_directory.h.in configuration/root_directory.h)
 include_directories(${CMAKE_BINARY_DIR}/configuration)
@@ -185,56 +194,70 @@ macro(makeLink src dest target)
   add_custom_command(TARGET ${target} POST_BUILD COMMAND ${CMAKE_COMMAND} -E create_symlink ${src} ${dest}  DEPENDS  ${dest} COMMENT "mklink ${src} -> ${dest}")
 endmacro()
 
+function(create_project_from_sources chapter demo)
+	file(GLOB SOURCE
+            "src/${chapter}/${demo}/*.h"
+            "src/${chapter}/${demo}/*.cpp"
+            "src/${chapter}/${demo}/*.vs"
+            "src/${chapter}/${demo}/*.fs"
+            "src/${chapter}/${demo}/*.gs"
+    )
+	if (demo STREQUAL "")
+		SET(replaced "")
+		string(REPLACE "/" "_" replaced ${chapter})
+		set(NAME ${replaced})
+	else()
+		set(NAME "${chapter}__${demo}")
+	endif()
+    add_executable(${NAME} ${SOURCE})
+    target_link_libraries(${NAME} ${LIBS})
+    if(MSVC)
+		target_compile_options(${NAME} PRIVATE /std:c++latest /MP)
+        target_link_options(${NAME} PUBLIC /ignore:4099)
+    endif(MSVC)
+    if(WIN32)
+        set_target_properties(${NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin/${chapter}")
+        set_target_properties(${NAME} PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/bin/${chapter}/Debug")
+    elseif(UNIX AND NOT APPLE)
+        set_target_properties(${NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin/${chapter}")
+    elseif(APPLE)
+        set_target_properties(${NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin/${chapter}")
+        set_target_properties(${NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY_DEBUG "${CMAKE_SOURCE_DIR}/bin/${chapter}")
+        set_target_properties(${NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY_RELEASE "${CMAKE_SOURCE_DIR}/bin/${chapter}")
+    endif(WIN32)
+    # copy shader files to build directory
+    file(GLOB SHADERS
+             "src/${chapter}/${demo}/*.vs"
+             # "src/${chapter}/${demo}/*.frag"
+             "src/${chapter}/${demo}/*.fs"
+             "src/${chapter}/${demo}/*.gs"
+    )
+    foreach(SHADER ${SHADERS})
+        if(WIN32)
+            # configure_file(${SHADER} "test")
+            add_custom_command(TARGET ${NAME} PRE_BUILD COMMAND ${CMAKE_COMMAND} -E copy ${SHADER} $<TARGET_FILE_DIR:${NAME}>)
+        elseif(UNIX AND NOT APPLE)
+            file(COPY ${SHADER} DESTINATION ${CMAKE_SOURCE_DIR}/bin/${chapter})
+        elseif(APPLE)
+            # create symbolic link for *.vs *.fs *.gs
+            get_filename_component(SHADERNAME ${SHADER} NAME)
+            makeLink(${SHADER} ${CMAKE_SOURCE_DIR}/bin/${chapter}/${SHADERNAME} ${NAME})
+        endif(WIN32)
+    endforeach(SHADER)
+    # if compiling for visual studio, also use configure file for each project (specifically to set up working directory)
+    if(MSVC)
+        configure_file(${CMAKE_SOURCE_DIR}/configuration/visualstudio.vcxproj.user.in ${CMAKE_CURRENT_BINARY_DIR}/${NAME}.vcxproj.user @ONLY)
+    endif(MSVC)
+endfunction()
+
 # then create a project file per tutorial
 foreach(CHAPTER ${CHAPTERS})
     foreach(DEMO ${${CHAPTER}})
-        file(GLOB SOURCE
-            "src/${CHAPTER}/${DEMO}/*.h"
-            "src/${CHAPTER}/${DEMO}/*.cpp"
-            "src/${CHAPTER}/${DEMO}/*.vs"
-            "src/${CHAPTER}/${DEMO}/*.fs"
-            "src/${CHAPTER}/${DEMO}/*.gs"
-        )
-        set(NAME "${CHAPTER}__${DEMO}")
-        add_executable(${NAME} ${SOURCE})
-        target_link_libraries(${NAME} ${LIBS})
-        if(MSVC)
-            target_link_options(${NAME} PUBLIC /ignore:4099)
-        endif(MSVC)
-        if(WIN32)
-            set_target_properties(${NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin/${CHAPTER}")
-            set_target_properties(${NAME} PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/bin/${CHAPTER}/Debug")
-        elseif(UNIX AND NOT APPLE)
-            set_target_properties(${NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin/${CHAPTER}")
-        elseif(APPLE)
-            set_target_properties(${NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin/${CHAPTER}")
-            set_target_properties(${NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY_DEBUG "${CMAKE_SOURCE_DIR}/bin/${CHAPTER}")
-            set_target_properties(${NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY_RELEASE "${CMAKE_SOURCE_DIR}/bin/${CHAPTER}")
-        endif(WIN32)
-        # copy shader files to build directory
-        file(GLOB SHADERS
-                 "src/${CHAPTER}/${DEMO}/*.vs"
-                 # "src/${CHAPTER}/${DEMO}/*.frag"
-                 "src/${CHAPTER}/${DEMO}/*.fs"
-                 "src/${CHAPTER}/${DEMO}/*.gs"
-        )
-        foreach(SHADER ${SHADERS})
-            if(WIN32)
-                # configure_file(${SHADER} "test")
-                add_custom_command(TARGET ${NAME} PRE_BUILD COMMAND ${CMAKE_COMMAND} -E copy ${SHADER} $<TARGET_FILE_DIR:${NAME}>)
-            elseif(UNIX AND NOT APPLE)
-                file(COPY ${SHADER} DESTINATION ${CMAKE_SOURCE_DIR}/bin/${CHAPTER})
-            elseif(APPLE)
-                # create symbolic link for *.vs *.fs *.gs
-                get_filename_component(SHADERNAME ${SHADER} NAME)
-                makeLink(${SHADER} ${CMAKE_SOURCE_DIR}/bin/${CHAPTER}/${SHADERNAME} ${NAME})
-            endif(WIN32)
-        endforeach(SHADER)
-        # if compiling for visual studio, also use configure file for each project (specifically to set up working directory)
-        if(MSVC)
-            configure_file(${CMAKE_SOURCE_DIR}/configuration/visualstudio.vcxproj.user.in ${CMAKE_CURRENT_BINARY_DIR}/${NAME}.vcxproj.user @ONLY)
-        endif(MSVC)
+		create_project_from_sources(${CHAPTER} ${DEMO})
     endforeach(DEMO)
 endforeach(CHAPTER)
+foreach(GUEST_ARTICLE ${GUEST_ARTICLES})
+	create_project_from_sources(${GUEST_ARTICLE} "")
+endforeach(GUEST_ARTICLE)
 
 include_directories(${CMAKE_SOURCE_DIR}/includes)

--- a/build_windows.sh
+++ b/build_windows.sh
@@ -1,0 +1,5 @@
+mkdir -p out
+cd out
+
+cmake -G"Visual Studio 16 2019" ${COMMON_CMAKE_CONFIG_PARAMS} ../
+cmake --build . --config Debug


### PR DESCRIPTION
The guest articles currently are not built by the CMake file, because they are in a different folder structure than the regular articles. This PR fixes that. This should make it easier for readers to test and and understand the topics discussed. There are some compile/linking issues with most guest articles, but I guess the authors can probably fix those easily. [Mine](https://learnopengl.com/Guest-Articles/2021/CSM) builds without hiccups for example, but the frustum culling project misses the assimp .dll.

I also added a shell script to make windows builds more convenient.