### PR TITLE
Fixed errors in skeletal animation code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,7 +171,7 @@ set(7.in_practice
 
 set(GUEST_ARTICLES
 	8.guest/2020/oit
-	#8.guest/2020/skeletal_animation
+	8.guest/2020/skeletal_animation
 	8.guest/2021/1.scene/1.scene_graph
 	8.guest/2021/1.scene/2.frustum_culling
 	8.guest/2021/2.csm

--- a/includes/learnopengl/animator.h
+++ b/includes/learnopengl/animator.h
@@ -22,7 +22,7 @@ public:
 			m_FinalBoneMatrices.push_back(glm::mat4(1.0f));
 	}
 
-	void Animator::UpdateAnimation(float dt)
+	void UpdateAnimation(float dt)
 	{
 		m_DeltaTime = dt;
 		if (m_CurrentAnimation)
@@ -33,13 +33,13 @@ public:
 		}
 	}
 
-	void Animator::PlayAnimation(Animation* pAnimation)
+	void PlayAnimation(Animation* pAnimation)
 	{
 		m_CurrentAnimation = pAnimation;
 		m_CurrentTime = 0.0f;
 	}
 
-	void Animator::CalculateBoneTransform(const AssimpNodeData* node, glm::mat4 parentTransform)
+	void CalculateBoneTransform(const AssimpNodeData* node, glm::mat4 parentTransform)
 	{
 		std::string nodeName = node->name;
 		glm::mat4 nodeTransform = node->transformation;

--- a/includes/learnopengl/bone.h
+++ b/includes/learnopengl/bone.h
@@ -160,7 +160,7 @@ private:
 
 	}
 
-	glm::mat4 Bone::InterpolateScaling(float animationTime)
+	glm::mat4 InterpolateScaling(float animationTime)
 	{
 		if (1 == m_NumScalings)
 			return glm::scale(glm::mat4(1.0f), m_Scales[0].scale);

--- a/src/8.guest/2020/skeletal_animation/anim_model.fs
+++ b/src/8.guest/2020/skeletal_animation/anim_model.fs
@@ -1,4 +1,4 @@
-#version 430 core
+#version 330 core
 out vec4 FragColor;
 
 in vec2 TexCoords;

--- a/src/8.guest/2020/skeletal_animation/anim_model.vs
+++ b/src/8.guest/2020/skeletal_animation/anim_model.vs
@@ -1,4 +1,4 @@
-#version 430 core
+#version 330 core
 
 layout(location = 0) in vec3 pos;
 layout(location = 1) in vec3 norm;

--- a/src/8.guest/2020/skeletal_animation/skeletal_animation.cpp
+++ b/src/8.guest/2020/skeletal_animation/skeletal_animation.cpp
@@ -124,7 +124,7 @@ int main()
 		ourShader.setMat4("projection", projection);
 		ourShader.setMat4("view", view);
 
-		auto transforms = animator.GetPoseTransforms();
+        auto transforms = animator.GetFinalBoneMatrices();
 		for (int i = 0; i < transforms.size(); ++i)
 			ourShader.setMat4("finalBonesTransformations[" + std::to_string(i) + "]", transforms[i]);
 


### PR DESCRIPTION
Fixed syntax errors in animator.h, bone.h and skeletal_animation.cpp. I have also changed version code in shaders to 330 because GLSL compiler was logging errors regarding that. Thanks.