### PR TITLE
corrected uniform name for bone transformations

### DIFF
--- a/src/8.guest/2020/skeletal_animation/skeletal_animation.cpp
+++ b/src/8.guest/2020/skeletal_animation/skeletal_animation.cpp
@@ -126,7 +126,7 @@ int main()
 
         auto transforms = animator.GetFinalBoneMatrices();
 		for (int i = 0; i < transforms.size(); ++i)
-			ourShader.setMat4("finalBonesTransformations[" + std::to_string(i) + "]", transforms[i]);
+			ourShader.setMat4("finalBonesMatrices[" + std::to_string(i) + "]", transforms[i]);
 
 
 		// render the loaded model


### PR DESCRIPTION
The uniform name wasn't matching with what's declared in shader "anim_model.vs". It should be "finalBonesMatrices" instead of "finalBonesTransformations" which is corrected.