### PR TITLE
Fix loading of entities in scene graph example

### DIFF
--- a/src/8.guest/2021/1.scene/1.scene_graph/scene_graph.cpp
+++ b/src/8.guest/2021/1.scene/1.scene_graph/scene_graph.cpp
@@ -98,7 +98,7 @@ int main()
 
 	// load entities
 	// -----------
-  Model model = Model(FileSystem::getPath("resources/objects/planet/planet.obj"));
+	Model model = Model(FileSystem::getPath("resources/objects/planet/planet.obj"));
 	Entity ourEntity(model);
 	ourEntity.transform.setLocalPosition({ 10, 0, 0 });
 	const float scale = 0.75;
@@ -109,7 +109,6 @@ int main()
 
 		for (unsigned int i = 0; i < 10; ++i)
 		{
-      Model model = Model(FileSystem::getPath("resources/objects/planet/planet.obj"));
 			lastEntity->addChild(model);
 			lastEntity = lastEntity->children.back().get();
 


### PR DESCRIPTION
Before only 1 planet was visualized.

I've used the same approach as in [frustum_culling.cpp](https://github.com/JoeyDeVries/LearnOpenGL/blob/166aeced4b950daf8f7617a8e68568a9e500970f/src/8.guest/2021/1.scene/2.frustum_culling/frustum_culling.cpp#L117).