### PR TITLE
[scenegraph] Fix update of model matrix

### DIFF
--- a/includes/learnopengl/entity.h
+++ b/includes/learnopengl/entity.h
@@ -38,11 +38,13 @@ public:
 	void computeModelMatrix()
 	{
 		m_modelMatrix = getLocalModelMatrix();
+		m_isDirty = false;
 	}
 
 	void computeModelMatrix(const glm::mat4& parentGlobalModelMatrix)
 	{
 		m_modelMatrix = parentGlobalModelMatrix * getLocalModelMatrix();
+		m_isDirty = false;
 	}
 
 	void setLocalPosition(const glm::vec3& newPosition)
@@ -439,10 +441,15 @@ public:
 	//Update transform if it was changed
 	void updateSelfAndChild()
 	{
-		if (!transform.isDirty())
+		if (transform.isDirty()) {
+			forceUpdateSelfAndChild();
 			return;
-
-		forceUpdateSelfAndChild();
+		}
+			
+		for (auto&& child : children)
+		{
+			child->updateSelfAndChild();
+		}
 	}
 
 	//Force update of transform even if local space don't change


### PR DESCRIPTION
The `m_isDirty` flag is never set to false currently.

Also, `updateSelfAndChild()` should check if any child is dirty, not just the current `Entity`.