### PR TITLE
Skeletal animation project fix + windows DLL copy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,10 +236,13 @@ function(create_project_from_sources chapter demo)
              "src/${chapter}/${demo}/*.fs"
              "src/${chapter}/${demo}/*.gs"
     )
+	# copy dlls
+	file(GLOB DLLS "dlls/*.dll")
     foreach(SHADER ${SHADERS})
         if(WIN32)
             # configure_file(${SHADER} "test")
             add_custom_command(TARGET ${NAME} PRE_BUILD COMMAND ${CMAKE_COMMAND} -E copy ${SHADER} $<TARGET_FILE_DIR:${NAME}>)
+			add_custom_command(TARGET ${NAME} PRE_BUILD COMMAND ${CMAKE_COMMAND} -E copy ${DLLS} $<TARGET_FILE_DIR:${NAME}>)
         elseif(UNIX AND NOT APPLE)
             file(COPY ${SHADER} DESTINATION ${CMAKE_SOURCE_DIR}/bin/${chapter})
         elseif(APPLE)

--- a/src/8.guest/2020/skeletal_animation/anim_model.vs
+++ b/src/8.guest/2020/skeletal_animation/anim_model.vs
@@ -3,8 +3,10 @@
 layout(location = 0) in vec3 pos;
 layout(location = 1) in vec3 norm;
 layout(location = 2) in vec2 tex;
-layout(location = 3) in ivec4 boneIds; 
-layout(location = 4) in vec4 weights;
+layout(location = 3) in vec3 tangent;
+layout(location = 4) in vec3 bitangent;
+layout(location = 5) in ivec4 boneIds; 
+layout(location = 6) in vec4 weights;
 
 uniform mat4 projection;
 uniform mat4 view;


### PR DESCRIPTION
There was a bug in the skeletal animation guest article's vertex shader. This fixes it. Also I made it so that .dlls get copied to all the build directories because some projects (for example the skeletal animation one) use them. This is not the best solution but it works.