### PR TITLE
Fixed models using other model's textures bug

### DIFF
--- a/includes/learnopengl/mesh.h
+++ b/includes/learnopengl/mesh.h
@@ -91,7 +91,11 @@ public:
         glBindVertexArray(0);
 
         // always good practice to set everything back to defaults once configured.
-        glActiveTexture(GL_TEXTURE0);
+    	for (unsigned int i = 0; i < textures.size(); i++)
+    	{
+    	    glActiveTexture(GL_TEXTURE0 + i);
+    	    glBindTexture(GL_TEXTURE_2D, 0);
+    	}
     }
 
 private:


### PR DESCRIPTION
Hello! First of all I love your tutorials SO MUCH! Thank you for them!

I noticed that when you load a model that does not have a diffuse, specular, normal or height map it will use the one from the previously rendered model. What I have here was my simple fix to the issue. This should also be able to close issue #317 .