### PR TITLE
[CSM guest article] Fixed float::min usage instead of float::lowest

### DIFF
--- a/src/8.guest/2021/2.csm/shadow_mapping.cpp
+++ b/src/8.guest/2021/2.csm/shadow_mapping.cpp
@@ -676,11 +676,11 @@ glm::mat4 getLightSpaceMatrix(const float nearPlane, const float farPlane)
     const auto lightView = glm::lookAt(center + lightDir, center, glm::vec3(0.0f, 1.0f, 0.0f));
 
     float minX = std::numeric_limits<float>::max();
-    float maxX = std::numeric_limits<float>::min();
+    float maxX = std::numeric_limits<float>::lowest();
     float minY = std::numeric_limits<float>::max();
-    float maxY = std::numeric_limits<float>::min();
+    float maxY = std::numeric_limits<float>::lowest();
     float minZ = std::numeric_limits<float>::max();
-    float maxZ = std::numeric_limits<float>::min();
+    float maxZ = std::numeric_limits<float>::lowest();
     for (const auto& v : corners)
     {
         const auto trf = lightView * v;


### PR DESCRIPTION
Please see this comment: http://disq.us/p/2rdhett

One of the readers kindly pointed out that I used the wrong function here. 🥲  @JoeyDeVries would you be so kind to merge it, and change the function names in the article too is possible? This part, in the code block: 
![image](https://user-images.githubusercontent.com/30218971/198399336-8ef0ac71-7f00-4a0b-9124-77e86b3af488.png)
