### PR TITLE
Fix linking errors with STB

### DIFF
--- a/src/1.getting_started/4.1.textures/textures.cpp
+++ b/src/1.getting_started/4.1.textures/textures.cpp
@@ -1,5 +1,7 @@
 #include <glad/glad.h>
 #include <GLFW/glfw3.h>
+
+#define STB_IMAGE_IMPLEMENTATION
 #include <stb_image.h>
 
 #include <learnopengl/filesystem.h>


### PR DESCRIPTION
I couldn't link it because of no STB implemenation. 

As we have just one cpp file it's quite reasonable to put this define here.