### PR TITLE
Fixed normal calculation in PBR shaders

### DIFF
--- a/src/6.pbr/1.1.lighting/1.1.pbr.vs
+++ b/src/6.pbr/1.1.lighting/1.1.pbr.vs
@@ -10,12 +10,13 @@ out vec3 Normal;
 uniform mat4 projection;
 uniform mat4 view;
 uniform mat4 model;
+uniform mat3 normalMatrix;
 
 void main()
 {
     TexCoords = aTexCoords;
     WorldPos = vec3(model * vec4(aPos, 1.0));
-    Normal = mat3(model) * aNormal;   
+    Normal = normalMatrix * aNormal;   
 
     gl_Position =  projection * view * vec4(WorldPos, 1.0);
 }

--- a/src/6.pbr/1.1.lighting/lighting.cpp
+++ b/src/6.pbr/1.1.lighting/lighting.cpp
@@ -151,6 +151,7 @@ int main()
                     0.0f
                 ));
                 shader.setMat4("model", model);
+                shader.setMat3("normalMatrix", glm::transpose(glm::inverse(glm::mat3(model))));
                 renderSphere();
             }
         }
@@ -169,6 +170,7 @@ int main()
             model = glm::translate(model, newPos);
             model = glm::scale(model, glm::vec3(0.5f));
             shader.setMat4("model", model);
+            shader.setMat3("normalMatrix", glm::transpose(glm::inverse(glm::mat3(model))));
             renderSphere();
         }
 

--- a/src/6.pbr/1.2.lighting_textured/1.2.pbr.vs
+++ b/src/6.pbr/1.2.lighting_textured/1.2.pbr.vs
@@ -10,12 +10,13 @@ out vec3 Normal;
 uniform mat4 projection;
 uniform mat4 view;
 uniform mat4 model;
+uniform mat3 normalMatrix;
 
 void main()
 {
     TexCoords = aTexCoords;
     WorldPos = vec3(model * vec4(aPos, 1.0));
-    Normal = mat3(model) * aNormal;   
+    Normal = normalMatrix * aNormal;   
 
     gl_Position =  projection * view * vec4(WorldPos, 1.0);
 }

--- a/src/6.pbr/1.2.lighting_textured/lighting_textured.cpp
+++ b/src/6.pbr/1.2.lighting_textured/lighting_textured.cpp
@@ -162,6 +162,7 @@ int main()
                     0.0f
                 ));
                 shader.setMat4("model", model);
+                shader.setMat3("normalMatrix", glm::transpose(glm::inverse(glm::mat3(model))));
                 renderSphere();
             }
         }
@@ -180,6 +181,7 @@ int main()
             model = glm::translate(model, newPos);
             model = glm::scale(model, glm::vec3(0.5f));
             shader.setMat4("model", model);
+            shader.setMat3("normalMatrix", glm::transpose(glm::inverse(glm::mat3(model))));
             renderSphere();
         }
 

--- a/src/6.pbr/2.1.1.ibl_irradiance_conversion/2.1.1.pbr.vs
+++ b/src/6.pbr/2.1.1.ibl_irradiance_conversion/2.1.1.pbr.vs
@@ -10,12 +10,13 @@ out vec3 Normal;
 uniform mat4 projection;
 uniform mat4 view;
 uniform mat4 model;
+uniform mat3 normalMatrix;
 
 void main()
 {
     TexCoords = aTexCoords;
     WorldPos = vec3(model * vec4(aPos, 1.0));
-    Normal = mat3(model) * aNormal;   
+    Normal = normalMatrix * aNormal;   
 
     gl_Position =  projection * view * vec4(WorldPos, 1.0);
 }

--- a/src/6.pbr/2.1.1.ibl_irradiance_conversion/ibl_irradiance_conversion.cpp
+++ b/src/6.pbr/2.1.1.ibl_irradiance_conversion/ibl_irradiance_conversion.cpp
@@ -252,6 +252,7 @@ int main()
                     -2.0f
                 ));
                 pbrShader.setMat4("model", model);
+                pbrShader.setMat3("normalMatrix", glm::transpose(glm::inverse(glm::mat3(model))));
                 renderSphere();
             }
         }
@@ -271,6 +272,7 @@ int main()
             model = glm::translate(model, newPos);
             model = glm::scale(model, glm::vec3(0.5f));
             pbrShader.setMat4("model", model);
+            pbrShader.setMat3("normalMatrix", glm::transpose(glm::inverse(glm::mat3(model))));
             renderSphere();
         }
 

--- a/src/6.pbr/2.1.2.ibl_irradiance/2.1.2.pbr.vs
+++ b/src/6.pbr/2.1.2.ibl_irradiance/2.1.2.pbr.vs
@@ -10,12 +10,13 @@ out vec3 Normal;
 uniform mat4 projection;
 uniform mat4 view;
 uniform mat4 model;
+uniform mat3 normalMatrix;
 
 void main()
 {
     TexCoords = aTexCoords;
     WorldPos = vec3(model * vec4(aPos, 1.0));
-    Normal = mat3(model) * aNormal;   
+    Normal = normalMatrix * aNormal;   
 
     gl_Position =  projection * view * vec4(WorldPos, 1.0);
 }

--- a/src/6.pbr/2.1.2.ibl_irradiance/ibl_irradiance.cpp
+++ b/src/6.pbr/2.1.2.ibl_irradiance/ibl_irradiance.cpp
@@ -297,6 +297,7 @@ int main()
                     -2.0f
                 ));
                 pbrShader.setMat4("model", model);
+                pbrShader.setMat3("normalMatrix", glm::transpose(glm::inverse(glm::mat3(model))));
                 renderSphere();
             }
         }
@@ -316,6 +317,7 @@ int main()
             model = glm::translate(model, newPos);
             model = glm::scale(model, glm::vec3(0.5f));
             pbrShader.setMat4("model", model);
+            pbrShader.setMat3("normalMatrix", glm::transpose(glm::inverse(glm::mat3(model))));
             renderSphere();
         }
 

--- a/src/6.pbr/2.2.1.ibl_specular/2.2.1.pbr.vs
+++ b/src/6.pbr/2.2.1.ibl_specular/2.2.1.pbr.vs
@@ -10,12 +10,13 @@ out vec3 Normal;
 uniform mat4 projection;
 uniform mat4 view;
 uniform mat4 model;
+uniform mat3 normalMatrix;
 
 void main()
 {
     TexCoords = aTexCoords;
     WorldPos = vec3(model * vec4(aPos, 1.0));
-    Normal = mat3(model) * aNormal;   
+    Normal = normalMatrix * aNormal;   
 
     gl_Position =  projection * view * vec4(WorldPos, 1.0);
 }

--- a/src/6.pbr/2.2.1.ibl_specular/ibl_specular.cpp
+++ b/src/6.pbr/2.2.1.ibl_specular/ibl_specular.cpp
@@ -389,6 +389,7 @@ int main()
                     -2.0f
                 ));
                 pbrShader.setMat4("model", model);
+                pbrShader.setMat3("normalMatrix", glm::transpose(glm::inverse(glm::mat3(model))));
                 renderSphere();
             }
         }
@@ -408,6 +409,7 @@ int main()
             model = glm::translate(model, newPos);
             model = glm::scale(model, glm::vec3(0.5f));
             pbrShader.setMat4("model", model);
+            pbrShader.setMat3("normalMatrix", glm::transpose(glm::inverse(glm::mat3(model))));
             renderSphere();
         }
 

--- a/src/6.pbr/2.2.2.ibl_specular_textured/2.2.2.pbr.vs
+++ b/src/6.pbr/2.2.2.ibl_specular_textured/2.2.2.pbr.vs
@@ -10,12 +10,13 @@ out vec3 Normal;
 uniform mat4 projection;
 uniform mat4 view;
 uniform mat4 model;
+uniform mat3 normalMatrix;
 
 void main()
 {
     TexCoords = aTexCoords;
     WorldPos = vec3(model * vec4(aPos, 1.0));
-    Normal = mat3(model) * aNormal;   
+    Normal = normalMatrix * aNormal;   
 
     gl_Position =  projection * view * vec4(WorldPos, 1.0);
 }

--- a/src/6.pbr/2.2.2.ibl_specular_textured/ibl_specular_textured.cpp
+++ b/src/6.pbr/2.2.2.ibl_specular_textured/ibl_specular_textured.cpp
@@ -424,6 +424,7 @@ int main()
         model = glm::mat4(1.0f);
         model = glm::translate(model, glm::vec3(-5.0, 0.0, 2.0));
         pbrShader.setMat4("model", model);
+        pbrShader.setMat3("normalMatrix", glm::transpose(glm::inverse(glm::mat3(model))));
         renderSphere();
 
         // gold
@@ -441,6 +442,7 @@ int main()
         model = glm::mat4(1.0f);
         model = glm::translate(model, glm::vec3(-3.0, 0.0, 2.0));
         pbrShader.setMat4("model", model);
+        pbrShader.setMat3("normalMatrix", glm::transpose(glm::inverse(glm::mat3(model))));
         renderSphere();
 
         // grass
@@ -458,6 +460,7 @@ int main()
         model = glm::mat4(1.0f);
         model = glm::translate(model, glm::vec3(-1.0, 0.0, 2.0));
         pbrShader.setMat4("model", model);
+        pbrShader.setMat3("normalMatrix", glm::transpose(glm::inverse(glm::mat3(model))));
         renderSphere();
 
         // plastic
@@ -475,6 +478,7 @@ int main()
         model = glm::mat4(1.0f);
         model = glm::translate(model, glm::vec3(1.0, 0.0, 2.0));
         pbrShader.setMat4("model", model);
+        pbrShader.setMat3("normalMatrix", glm::transpose(glm::inverse(glm::mat3(model))));
         renderSphere();
 
         // wall
@@ -492,6 +496,7 @@ int main()
         model = glm::mat4(1.0f);
         model = glm::translate(model, glm::vec3(3.0, 0.0, 2.0));
         pbrShader.setMat4("model", model);
+        pbrShader.setMat3("normalMatrix", glm::transpose(glm::inverse(glm::mat3(model))));
         renderSphere();
 
         // render light source (simply re-render sphere at light positions)
@@ -508,6 +513,7 @@ int main()
             model = glm::translate(model, newPos);
             model = glm::scale(model, glm::vec3(0.5f));
             pbrShader.setMat4("model", model);
+            pbrShader.setMat3("normalMatrix", glm::transpose(glm::inverse(glm::mat3(model))));
             renderSphere();
         }
 


### PR DESCRIPTION
 I think normals are currently calculated incorrectly in the PBR vertex shaders. It is just a lucky coincidence that they work I guess because of the sphere models 🤔 
 We should be multiplying the vertex normals with the proper normal matrix. While this PR does not change the result of the calculation, we should avoid someone copying this code and it not working in their engine and them spending hours debugging.
 
 Let me know if I misunderstood something and the currect calculations are in fact correct.