### PR TITLE
fix:  explicitly hint GLFW to use msaa

### DIFF
--- a/src/4.advanced_opengl/11.1.anti_aliasing_msaa/anti_aliasing_msaa.cpp
+++ b/src/4.advanced_opengl/11.1.anti_aliasing_msaa/anti_aliasing_msaa.cpp
@@ -40,6 +40,7 @@ int main()
     glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
     glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
     glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+    glfwWindowHint(GLFW_SAMPLES, 4);
 
 #ifdef __APPLE__
     glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);


### PR DESCRIPTION
add `glfwWindowHint(GLFW_SAMPLES, 4);` to explicitly hint GLFW to use msaa, otherwise it doesnt work as expected.

