### PR TITLE
2.3.csm: fix mac os issues

### DIFF
--- a/src/8.guest/2021/2.csm/10.debug_cascade.fs
+++ b/src/8.guest/2021/2.csm/10.debug_cascade.fs
@@ -1,4 +1,4 @@
-#version 460 core
+#version 410 core
 out vec4 FragColor;
 
 uniform vec4 color;

--- a/src/8.guest/2021/2.csm/10.debug_cascade.vs
+++ b/src/8.guest/2021/2.csm/10.debug_cascade.vs
@@ -1,4 +1,4 @@
-#version 460 core
+#version 410 core
 layout (location = 0) in vec3 aPos;
 
 uniform mat4 view;

--- a/src/8.guest/2021/2.csm/10.debug_quad.vs
+++ b/src/8.guest/2021/2.csm/10.debug_quad.vs
@@ -1,4 +1,4 @@
-#version 460 core
+#version 410 core
 layout (location = 0) in vec3 aPos;
 layout (location = 1) in vec2 aTexCoords;
 

--- a/src/8.guest/2021/2.csm/10.debug_quad_depth.fs
+++ b/src/8.guest/2021/2.csm/10.debug_quad_depth.fs
@@ -1,4 +1,4 @@
-#version 460 core
+#version 410 core
 out vec4 FragColor;
 
 in vec2 TexCoords;

--- a/src/8.guest/2021/2.csm/10.shadow_mapping.fs
+++ b/src/8.guest/2021/2.csm/10.shadow_mapping.fs
@@ -1,4 +1,4 @@
-#version 460 core
+#version 410 core
 out vec4 FragColor;
 
 in VS_OUT {
@@ -16,7 +16,7 @@ uniform float farPlane;
 
 uniform mat4 view;
 
-layout (std140, binding = 0) uniform LightSpaceMatrices
+layout (std140) uniform LightSpaceMatrices
 {
     mat4 lightSpaceMatrices[16];
 };

--- a/src/8.guest/2021/2.csm/10.shadow_mapping.vs
+++ b/src/8.guest/2021/2.csm/10.shadow_mapping.vs
@@ -1,4 +1,4 @@
-#version 460 core
+#version 410 core
 layout (location = 0) in vec3 aPos;
 layout (location = 1) in vec3 aNormal;
 layout (location = 2) in vec2 aTexCoords;

--- a/src/8.guest/2021/2.csm/10.shadow_mapping_depth.fs
+++ b/src/8.guest/2021/2.csm/10.shadow_mapping_depth.fs
@@ -1,4 +1,4 @@
-#version 460 core
+#version 410 core
 
 void main()
 {             

--- a/src/8.guest/2021/2.csm/10.shadow_mapping_depth.gs
+++ b/src/8.guest/2021/2.csm/10.shadow_mapping_depth.gs
@@ -1,12 +1,15 @@
-#version 460 core
+#version 410 core
 
 layout(triangles, invocations = 5) in;
 layout(triangle_strip, max_vertices = 3) out;
 
-layout (std140, binding = 0) uniform LightSpaceMatrices
+layout (std140/*, binding = 0*/) uniform LightSpaceMatrices
 {
     mat4 lightSpaceMatrices[16];
 };
+/*
+uniform mat4 lightSpaceMatrices[16];
+*/
 
 void main()
 {          

--- a/src/8.guest/2021/2.csm/10.shadow_mapping_depth.gs
+++ b/src/8.guest/2021/2.csm/10.shadow_mapping_depth.gs
@@ -3,7 +3,7 @@
 layout(triangles, invocations = 5) in;
 layout(triangle_strip, max_vertices = 3) out;
 
-layout (std140/*, binding = 0*/) uniform LightSpaceMatrices
+layout (std140) uniform LightSpaceMatrices
 {
     mat4 lightSpaceMatrices[16];
 };

--- a/src/8.guest/2021/2.csm/10.shadow_mapping_depth.vs
+++ b/src/8.guest/2021/2.csm/10.shadow_mapping_depth.vs
@@ -1,4 +1,4 @@
-#version 460 core
+#version 410 core
 layout (location = 0) in vec3 aPos;
 
 uniform mat4 model;

--- a/src/8.guest/2021/2.csm/shadow_mapping.cpp
+++ b/src/8.guest/2021/2.csm/shadow_mapping.cpp
@@ -72,8 +72,8 @@ int main()
     // glfw: initialize and configure
     // ------------------------------
     glfwInit();
-    glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
-    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 4);
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 1);
     glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
 
 #ifdef __APPLE__

--- a/src/8.guest/2021/2.csm/shadow_mapping.cpp
+++ b/src/8.guest/2021/2.csm/shadow_mapping.cpp
@@ -30,6 +30,10 @@ void drawCascadeVolumeVisualizers(const std::vector<glm::mat4>& lightMatrices, S
 const unsigned int SCR_WIDTH = 2560;
 const unsigned int SCR_HEIGHT = 1440;
 
+// framebuffer size
+int fb_width;
+int fb_height;
+
 // camera
 Camera camera(glm::vec3(0.0f, 0.0f, 3.0f));
 float lastX = (float)SCR_WIDTH / 2.0;
@@ -68,8 +72,8 @@ int main()
     // glfw: initialize and configure
     // ------------------------------
     glfwInit();
-    glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 4);
-    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 6);
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
     glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
 
 #ifdef __APPLE__
@@ -89,6 +93,7 @@ int main()
     glfwSetFramebufferSizeCallback(window, framebuffer_size_callback);
     glfwSetCursorPosCallback(window, mouse_callback);
     glfwSetScrollCallback(window, scroll_callback);
+    glfwGetFramebufferSize(window, &fb_width, &fb_height);
 
     // tell GLFW to capture our mouse
     glfwSetInputMode(window, GLFW_CURSOR, GLFW_CURSOR_DISABLED);
@@ -239,15 +244,15 @@ int main()
         glBindFramebuffer(GL_FRAMEBUFFER, 0);
 
         // reset viewport
-        glViewport(0, 0, SCR_WIDTH, SCR_HEIGHT);
+        glViewport(0, 0, fb_width, fb_height);
         glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
         // 2. render scene as normal using the generated depth/shadow map  
         // --------------------------------------------------------------
-        glViewport(0, 0, SCR_WIDTH, SCR_HEIGHT);
+        glViewport(0, 0, fb_width, fb_height);
         glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
         shader.use();
-        const glm::mat4 projection = glm::perspective(glm::radians(camera.Zoom), (float)SCR_WIDTH / (float)SCR_HEIGHT, cameraNearPlane, cameraFarPlane);
+        const glm::mat4 projection = glm::perspective(glm::radians(camera.Zoom), (float)fb_width / (float)fb_height, cameraNearPlane, cameraFarPlane);
         const glm::mat4 view = camera.GetViewMatrix();
         shader.setMat4("projection", projection);
         shader.setMat4("view", view);
@@ -540,7 +545,7 @@ void processInput(GLFWwindow *window)
     fPress = glfwGetKey(window, GLFW_KEY_F);
 
     static int plusPress = GLFW_RELEASE;
-    if (glfwGetKey(window, GLFW_KEY_KP_ADD) == GLFW_RELEASE && plusPress == GLFW_PRESS)
+    if (glfwGetKey(window, GLFW_KEY_N) == GLFW_RELEASE && plusPress == GLFW_PRESS)
     {
         debugLayer++;
         if (debugLayer > shadowCascadeLevels.size())
@@ -548,7 +553,7 @@ void processInput(GLFWwindow *window)
             debugLayer = 0;
         }
     }
-    plusPress = glfwGetKey(window, GLFW_KEY_KP_ADD);
+    plusPress = glfwGetKey(window, GLFW_KEY_N);
 
     static int cPress = GLFW_RELEASE;
     if (glfwGetKey(window, GLFW_KEY_C) == GLFW_RELEASE && cPress == GLFW_PRESS)
@@ -564,6 +569,8 @@ void framebuffer_size_callback(GLFWwindow* window, int width, int height)
 {
     // make sure the viewport matches the new window dimensions; note that width and 
     // height will be significantly larger than specified on retina displays.
+    fb_width = width;
+    fb_height = height;
     glViewport(0, 0, width, height);
 }
 
@@ -662,7 +669,7 @@ std::vector<glm::vec4> getFrustumCornersWorldSpace(const glm::mat4& proj, const 
 glm::mat4 getLightSpaceMatrix(const float nearPlane, const float farPlane)
 {
     const auto proj = glm::perspective(
-        glm::radians(camera.Zoom), (float)SCR_WIDTH / (float)SCR_HEIGHT, nearPlane,
+        glm::radians(camera.Zoom), (float)fb_width / (float)fb_height, nearPlane,
         farPlane);
     const auto corners = getFrustumCornersWorldSpace(proj, camera.GetViewMatrix());
 
@@ -712,7 +719,6 @@ glm::mat4 getLightSpaceMatrix(const float nearPlane, const float farPlane)
     }
 
     const glm::mat4 lightProjection = glm::ortho(minX, maxX, minY, maxY, minZ, maxZ);
-
     return lightProjection * lightView;
 }
 


### PR DESCRIPTION
1. Lower OpenGL demands: the demo works fine with v4.1. No need to require v4.6 which is not available on mac os.

2. Use actual framebuffer size to fix viewport issues on retina displays.