### PR TITLE
fix: 8.guest.2020.oit: binding point supported since core 4.2

### DIFF
--- a/src/8.guest/2020/oit/composite.fs
+++ b/src/8.guest/2020/oit/composite.fs
@@ -1,4 +1,4 @@
-#version 400 core
+#version 420 core
 
 // shader outputs
 layout (location = 0) out vec4 frag;

--- a/src/8.guest/2020/oit/composite.vs
+++ b/src/8.guest/2020/oit/composite.vs
@@ -1,4 +1,4 @@
-#version 400 core
+#version 420 core
 
 // shader inputs
 layout (location = 0) in vec3 position;

--- a/src/8.guest/2020/oit/screen.fs
+++ b/src/8.guest/2020/oit/screen.fs
@@ -1,4 +1,4 @@
-#version 400 core
+#version 420 core
 
 // shader inputs
 in vec2 texture_coords;

--- a/src/8.guest/2020/oit/screen.vs
+++ b/src/8.guest/2020/oit/screen.vs
@@ -1,4 +1,4 @@
-#version 400 core
+#version 420 core
 
 // shader inputs
 layout (location = 0) in vec3 position;

--- a/src/8.guest/2020/oit/solid.fs
+++ b/src/8.guest/2020/oit/solid.fs
@@ -1,4 +1,4 @@
-#version 400 core
+#version 420 core
 
 // shader outputs
 layout (location = 0) out vec4 frag;

--- a/src/8.guest/2020/oit/solid.vs
+++ b/src/8.guest/2020/oit/solid.vs
@@ -1,4 +1,4 @@
-#version 400 core
+#version 420 core
 
 // shader inputs
 layout (location = 0) in vec3 position;

--- a/src/8.guest/2020/oit/transparent.fs
+++ b/src/8.guest/2020/oit/transparent.fs
@@ -1,4 +1,4 @@
-#version 400 core
+#version 420 core
 
 // shader outputs
 layout (location = 0) out vec4 accum;

--- a/src/8.guest/2020/oit/transparent.vs
+++ b/src/8.guest/2020/oit/transparent.vs
@@ -1,4 +1,4 @@
-#version 400 core
+#version 420 core
 
 // shader inputs
 layout (location = 0) in vec3 position;

--- a/src/8.guest/2020/oit/weighted_blended.cpp
+++ b/src/8.guest/2020/oit/weighted_blended.cpp
@@ -36,7 +36,7 @@ int main(int argc, char* argv[])
 	// ------------------------------
 	glfwInit();
 	glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 4);
-	glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 0);
+	glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 2);
 	glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
 
 	#ifdef __APPLE__


### PR DESCRIPTION
error output:
```
ERROR::SHADER_COMPILATION_ERROR of type: FRAGMENT
ERROR: 0:7: 'binding' : not supported for this version or the enabled extensions
ERROR: 0:7: '' : compilation terminated
ERROR: 2 compilation errors.  No code generated.


 -- --------------------------------------------------- --
ERROR::PROGRAM_LINKING_ERROR of type: PROGRAM
Program Link Failed for unknown reason.

 -- --------------------------------------------------- --
```

OS & devices:  

1. Windows 11, AMD Radeon RX6750 XT  
2. Windows 10, NV GTX1650  

![image](https://github.com/JoeyDeVries/LearnOpenGL/assets/80660355/cb30370b-1836-4ef8-8820-72981fd233b4)
