### PR TITLE
typo correction

### DIFF
--- a/src/4.advanced_opengl/9.2.geometry_shader_exploding/geometry_shader_exploding.cpp
+++ b/src/4.advanced_opengl/9.2.geometry_shader_exploding/geometry_shader_exploding.cpp
@@ -103,7 +103,7 @@ int main()
 
         // configure transformation matrices
         glm::mat4 projection = glm::perspective(glm::radians(45.0f), (float)SCR_WIDTH / (float)SCR_HEIGHT, 1.0f, 100.0f);
-        glm::mat4 view = camera.GetViewMatrix();;
+        glm::mat4 view = camera.GetViewMatrix();
         glm::mat4 model = glm::mat4(1.0f);
         shader.use();
         shader.setMat4("projection", projection);


### PR DESCRIPTION
Hello,

Report a typo. 

`glm::mat4 view = camera.GetViewMatrix();;`

to

`glm::mat4 view = camera.GetViewMatrix();`