### PR TITLE
Fix paddle size exceeding screen bounds

### DIFF
--- a/src/7.in_practice/3.2d_game/0.full_source/game.cpp
+++ b/src/7.in_practice/3.2d_game/0.full_source/game.cpp
@@ -351,7 +351,7 @@ void Game::SpawnPowerUps(GameObject &block)
         this->PowerUps.push_back(PowerUp("chaos", glm::vec3(0.9f, 0.25f, 0.25f), 15.0f, block.Position, ResourceManager::GetTexture("powerup_chaos")));
 }
 
-void ActivatePowerUp(PowerUp &powerUp)
+void ActivatePowerUp(PowerUp &powerUp, unsigned int width)
 {
     if (powerUp.Type == "speed")
     {
@@ -367,7 +367,7 @@ void ActivatePowerUp(PowerUp &powerUp)
         Ball->PassThrough = true;
         Ball->Color = glm::vec3(1.0f, 0.5f, 0.5f);
     }
-    else if (powerUp.Type == "pad-size-increase")
+    else if (powerUp.Type == "pad-size-increase" && Player->Size.x <= (width / 2)) // add a fix so that paddle size does not exceed screen bounds
     {
         Player->Size.x += 50;
     }
@@ -465,7 +465,7 @@ void Game::DoCollisions()
 
             if (CheckCollision(*Player, powerUp))
             {	// collided with player, now activate powerup
-                ActivatePowerUp(powerUp);
+                ActivatePowerUp(powerUp, this->Width);
                 powerUp.Destroyed = true;
                 powerUp.Activated = true;
                 SoundEngine->play2D(FileSystem::getPath("resources/audio/powerup.wav").c_str(), false);

--- a/src/7.in_practice/3.2d_game/0.full_source/progress/8.game.cpp
+++ b/src/7.in_practice/3.2d_game/0.full_source/progress/8.game.cpp
@@ -272,7 +272,7 @@ void Game::SpawnPowerUps(GameObject &block)
         this->PowerUps.push_back(PowerUp("chaos", glm::vec3(0.9f, 0.25f, 0.25f), 15.0f, block.Position, ResourceManager::GetTexture("powerup_chaos")));
 }
 
-void ActivatePowerUp(PowerUp &powerUp)
+void ActivatePowerUp(PowerUp &powerUp, unsigned int width)
 {
     if (powerUp.Type == "speed")
     {
@@ -288,7 +288,7 @@ void ActivatePowerUp(PowerUp &powerUp)
         Ball->PassThrough = true;
         Ball->Color = glm::vec3(1.0f, 0.5f, 0.5f);
     }
-    else if (powerUp.Type == "pad-size-increase")
+    else if (powerUp.Type == "pad-size-increase" && Player->Size.x <= (width / 2)) // add a fix so that paddle size does not exceed screen bounds
     {
         Player->Size.x += 50;
     }
@@ -383,7 +383,7 @@ void Game::DoCollisions()
 
             if (CheckCollision(*Player, powerUp))
             {	// collided with player, now activate powerup
-                ActivatePowerUp(powerUp);
+                ActivatePowerUp(powerUp, this->Width);
                 powerUp.Destroyed = true;
                 powerUp.Activated = true;
             }

--- a/src/7.in_practice/3.2d_game/0.full_source/progress/9.game.cpp
+++ b/src/7.in_practice/3.2d_game/0.full_source/progress/9.game.cpp
@@ -279,7 +279,7 @@ void Game::SpawnPowerUps(GameObject &block)
         this->PowerUps.push_back(PowerUp("chaos", glm::vec3(0.9f, 0.25f, 0.25f), 15.0f, block.Position, ResourceManager::GetTexture("powerup_chaos")));
 }
 
-void ActivatePowerUp(PowerUp &powerUp)
+void ActivatePowerUp(PowerUp &powerUp, unsigned int width)
 {
     if (powerUp.Type == "speed")
     {
@@ -295,7 +295,7 @@ void ActivatePowerUp(PowerUp &powerUp)
         Ball->PassThrough = true;
         Ball->Color = glm::vec3(1.0f, 0.5f, 0.5f);
     }
-    else if (powerUp.Type == "pad-size-increase")
+    else if (powerUp.Type == "pad-size-increase" && Player->Size.x <= (width / 2)) // add a fix so that paddle size does not exceed screen bounds
     {
         Player->Size.x += 50;
     }
@@ -392,7 +392,7 @@ void Game::DoCollisions()
 
             if (CheckCollision(*Player, powerUp))
             {	// collided with player, now activate powerup
-                ActivatePowerUp(powerUp);
+                ActivatePowerUp(powerUp, this->Width);
                 powerUp.Destroyed = true;
                 powerUp.Activated = true;
                 SoundEngine->play2D("audio/powerup.wav", false);


### PR DESCRIPTION
Limit the paddle width to a fixed size (like half the screen) so that it does not exceed the screen bounds, which also does not allow the paddle to be moved. The problem is noticeable when `ShouldSpawn` is called with a lower number, or the game runs for a long period.

https://github.com/user-attachments/assets/b2be46d6-28ba-4532-b38f-10e00dae8b84