### PR TITLE
Fix unneccessary copy and query in animatior.h

### DIFF
--- a/includes/learnopengl/animator.h
+++ b/includes/learnopengl/animator.h
@@ -54,11 +54,12 @@ public:
 
 		glm::mat4 globalTransformation = parentTransform * nodeTransform;
 
-		auto boneInfoMap = m_CurrentAnimation->GetBoneIDMap();
-		if (boneInfoMap.find(nodeName) != boneInfoMap.end())
+		auto& boneInfoMap = m_CurrentAnimation->GetBoneIDMap();
+		auto boneInfo = boneInfoMap.find(nodeName);
+		if (boneInfo != boneInfoMap.end())
 		{
-			int index = boneInfoMap[nodeName].id;
-			glm::mat4 offset = boneInfoMap[nodeName].offset;
+			int index = boneInfo->second.id;
+			glm::mat4 offset = boneInfo->second.offset;
 			m_FinalBoneMatrices[index] = globalTransformation * offset;
 		}
 


### PR DESCRIPTION
The **auto** keyword in C++ will drop the **reference** and **top level const** in the type deduction.

The following code at animator.h line 57 will cause boneInfoMap be implicitly copied from the animation's member variable.
```C++
// animator.h
// boneInfoMap will be deduced to 
// std::map<std::string,BoneInfo> boneInfoMap
auto boneInfoMap = m_CurrentAnimation->GetBoneIDMap();

// animation.h Animation::GetBoneIDMap()
inline const std::map<std::string,BoneInfo>& GetBoneIDMap()  { 
    return m_BoneInfoMap;
}
```

Since the CalculateBoneTransform is implemented in the recursive fashion, every access to the animation node in the node tree hierarchy will implicitly copy the **boneInfoMap**, which may cause performance issue.

Besides, we can save the boneInfoMap query result, instead of querying it three times
```C++
// original code
auto boneInfoMap = m_CurrentAnimation->GetBoneIDMap();
if (boneInfoMap.find(nodeName) != boneInfoMap.end())  {
    int index = boneInfoMap[nodeName].id;
    glm::mat4 offset = boneInfoMap[nodeName].offset;
    m_FinalBoneMatrices[index] = globalTransformation * offset;
}

// modified code
auto& boneInfoMap = m_CurrentAnimation->GetBoneIDMap();
auto boneInfo = boneInfoMap.find(nodeName);
if (boneInfo != boneInfoMap.end()) {
    int index = boneInfo->second.id;
    glm::mat4 offset = boneInfo->second.offset;
    m_FinalBoneMatrices[index] = globalTransformation * offset;
}
```